### PR TITLE
Add PUG_OTEL stdout mode for deploys without an OTLP collector.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,11 @@ NATS_URL=nats://localhost:4222
 REDIS_URL=redis://localhost:6380
 
 # OpenTelemetry
+# PUG_OTEL (evaluated once at process start; default otlp when unset):
+#   otlp   — export traces, metrics, and logs to an OTLP collector (`make clickstack`)
+#   stdout — text logs on stdout, no collector (use for deploys without OTLP)
+# PUG_OTEL=stdout
+# Only needed when PUG_OTEL=otlp (or unset):
 OTEL_SERVICE_NAME=pug
 
 # Server

--- a/.env.example
+++ b/.env.example
@@ -13,11 +13,12 @@ NATS_URL=nats://localhost:4222
 REDIS_URL=redis://localhost:6380
 
 # OpenTelemetry
-# PUG_OTEL (evaluated once at process start; default otlp when unset):
-#   otlp   — export traces, metrics, and logs to an OTLP collector (`make clickstack`)
-#   stdout — text logs on stdout, no collector (use for deploys without OTLP)
-# PUG_OTEL=stdout
-# Only needed when PUG_OTEL=otlp (or unset):
+# Export mode is auto-detected once at process start: if an OTLP endpoint var is
+# set, pug exports traces, metrics, and logs to that collector; otherwise it logs
+# to stdout as text (no collector needed — use this for deploys without OTLP).
+# For local OTLP/HyperDX (`make clickstack`), uncomment the endpoint below.
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+# Only used when exporting via OTLP:
 OTEL_SERVICE_NAME=pug
 
 # Server

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,9 @@ make infra
 # Stop infrastructure
 make infra-down
 
+# OTLP collector + HyperDX (optional; for telemetry export)
+make clickstack
+
 # Run database migrations
 ./bin/pug postgres migrate
 ./bin/pug nats migrate
@@ -41,6 +44,8 @@ make infra-down
 ./bin/pug worker profile upsert
 ./bin/pug worker scheduler
 ```
+
+Environment variables are documented in `.env.example`. **`PUG_OTEL`** selects telemetry export (evaluated once on first `SetupSDK` in server/workers): unset or `otlp` → OTLP via `otelslog` (needs a collector, e.g. `make clickstack`); `stdout` → application logs as text on stdout with noop trace/metric export (use for deploys without OTLP). Set `OTEL_SERVICE_NAME` when exporting via OTLP.
 
 ### Code Generation
 
@@ -150,7 +155,7 @@ Deep per-subsystem documentation lives in [`docs/architecture/`](docs/architectu
 - **Profiles** — read API (ClickHouse-backed), activity summary, property model, soft-delete, device subscriptions → [`docs/architecture/profiles.md`](docs/architecture/profiles.md)
 - **Event ingestion enrichment** — geo, user-agent, and bot-management auto-properties → [`docs/architecture/ingestion.md`](docs/architecture/ingestion.md)
 - **Email templating** — templ + go-premailer rendering, frozen brand tokens, preview CLI → [`docs/architecture/email.md`](docs/architecture/email.md)
-- **OpenTelemetry** — provider bootstrap, per-component instrumentation status, the error-recording convention and its exceptions → [`docs/architecture/telemetry.md`](docs/architecture/telemetry.md)
+- **OpenTelemetry** — `internal/deps/telemetry/` (`SetupSDK`, `PUG_OTEL=otlp|stdout`), per-component instrumentation, slog bridge vs stdout handler, error-recording convention and exceptions → [`docs/architecture/telemetry.md`](docs/architecture/telemetry.md)
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ make clickstack
 ./bin/pug worker scheduler
 ```
 
-Environment variables are documented in `.env.example`. **`PUG_OTEL`** selects telemetry export (evaluated once on first `SetupSDK` in server/workers): unset or `otlp` → OTLP via `otelslog` (needs a collector, e.g. `make clickstack`); `stdout` → application logs as text on stdout with noop trace/metric export (use for deploys without OTLP). Set `OTEL_SERVICE_NAME` when exporting via OTLP.
+Environment variables are documented in `.env.example`. **Telemetry export is auto-detected** (decided once on first `SetupSDK` in server/workers): if any standard OTLP endpoint var is set (`OTEL_EXPORTER_OTLP_ENDPOINT`, or a per-signal `OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_ENDPOINT`), pug exports via OTLP (`otelslog`; needs a collector, e.g. `make clickstack`); otherwise it falls back to application logs as text on stdout with noop trace/metric export (use for deploys without a collector). There is no `PUG_OTEL` switch, and a present-but-blank endpoint counts as unset. Set `OTEL_SERVICE_NAME` when exporting via OTLP.
 
 ### Code Generation
 
@@ -155,7 +155,7 @@ Deep per-subsystem documentation lives in [`docs/architecture/`](docs/architectu
 - **Profiles** — read API (ClickHouse-backed), activity summary, property model, soft-delete, device subscriptions → [`docs/architecture/profiles.md`](docs/architecture/profiles.md)
 - **Event ingestion enrichment** — geo, user-agent, and bot-management auto-properties → [`docs/architecture/ingestion.md`](docs/architecture/ingestion.md)
 - **Email templating** — templ + go-premailer rendering, frozen brand tokens, preview CLI → [`docs/architecture/email.md`](docs/architecture/email.md)
-- **OpenTelemetry** — `internal/deps/telemetry/` (`SetupSDK`, `PUG_OTEL=otlp|stdout`), per-component instrumentation, slog bridge vs stdout handler, error-recording convention and exceptions → [`docs/architecture/telemetry.md`](docs/architecture/telemetry.md)
+- **OpenTelemetry** — `internal/deps/telemetry/` (`SetupSDK`; OTLP-vs-stdout auto-detected from the `OTEL_EXPORTER_OTLP_*` endpoint vars, no `PUG_OTEL`), per-component instrumentation, slog bridge vs stdout handler, error-recording convention and exceptions → [`docs/architecture/telemetry.md`](docs/architecture/telemetry.md)
 
 ## Code Style
 

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ infra: infra-up
 
 infra-up:
 	docker compose -f infra/dev/docker-compose.yaml up -d
-	@echo "Infra is up. For OTLP/HyperDX: make clickstack. Without a collector, set PUG_OTEL=stdout in .env."
+	@echo "Infra is up. Logs default to stdout. For OTLP/HyperDX: make clickstack, then set OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 in .env."
 
 infra-up-fg:
 	docker compose -f infra/dev/docker-compose.yaml up

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ infra: infra-up
 
 infra-up:
 	docker compose -f infra/dev/docker-compose.yaml up -d
+	@echo "Infra is up. For OTLP/HyperDX: make clickstack. Without a collector, set PUG_OTEL=stdout in .env."
 
 infra-up-fg:
 	docker compose -f infra/dev/docker-compose.yaml up

--- a/docs/architecture/telemetry.md
+++ b/docs/architecture/telemetry.md
@@ -13,13 +13,22 @@ All telemetry is bootstrapped in `internal/deps/telemetry/`. The server initiali
 | Component      | Status                                                                                                                   |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | Connect RPC    | ✅ — `otelconnect.Interceptor` on all handlers                                                                           |
-| slog → OTel    | ✅ — `otelslog` bridge replaces default logger                                                                           |
+| slog → OTel    | ✅ — `otelslog` bridge replaces default logger; with `PUG_OTEL=stdout`, text logs to stdout instead                        |
 | PostgreSQL     | ✅ — `otelpgx` tracer on all connections                                                                                 |
 | Redis          | ✅ — `redisotel` tracing + metrics on the client                                                                         |
 | NATS/JetStream | Custom — `tracedJetStream` wrapper in `internal/deps/nats/otel.go`, W3C trace context propagation on publish/consume     |
 | ClickHouse     | Custom — `Conn` wrapper in `internal/deps/clickhouse/clickhouse.go`, spans on Query/Exec/Select/PrepareBatch/AsyncInsert |
 
 **Configuration:** Set `OTEL_SERVICE_NAME` (strongly recommended — telemetry data will lack a service identifier without it) and `OTEL_EXPORTER_OTLP_ENDPOINT` (default `localhost:4317`). TLS is disabled by default (`OTEL_EXPORTER_OTLP_INSECURE` defaults to `true` when unset); set `OTEL_EXPORTER_OTLP_INSECURE=false` to enable TLS for production OTLP endpoints.
+
+**`PUG_OTEL` modes:**
+
+| Value | Behavior |
+| ----- | -------- |
+| *(unset)* or `otlp` | OTLP export via `otelslog` (requires a collector; dev default endpoint `localhost:4317`) |
+| `stdout` | Noop providers; text logs on stdout (no collector required) |
+
+`PUG_OTEL` is evaluated once per process on the first `SetupSDK` call — set it before starting the server or workers. Any other value fails startup (`ErrInvalidOtelMode`). For local dev with only `make infra`, set `PUG_OTEL=stdout`; run `make clickstack` and use `otlp` (or unset) when exporting to HyperDX.
 
 **Recording errors in spans:** Use `telemetry.RecordError(ctx, err)` to record an error on the current span, set the span status to `Error`, and attach stack traces.
 

--- a/docs/architecture/telemetry.md
+++ b/docs/architecture/telemetry.md
@@ -28,7 +28,7 @@ There is no `PUG_OTEL` switch. `SetupSDK` calls `resolveOtelMode()`, which retur
 | Condition | Behavior |
 | --------- | -------- |
 | Any of `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` / `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` set (non-blank) | OTLP export via `otelslog` (requires a collector) |
-| None set | Noop trace/metric providers; text logs on stdout (no collector required) |
+| None set | Noop trace/metric/log providers; application logs go to stdout as text via a slog handler (not the OTel log pipeline), no collector required |
 
 The mode is resolved once per process on the first `SetupSDK` call — set the endpoint var(s) before starting the server or workers. A present-but-blank endpoint (e.g. `OTEL_EXPORTER_OTLP_ENDPOINT=`) counts as unset, so a conditionally-templated empty value can't silently flip pug into exporting at a collector that isn't there. For local dev with only `make infra`, leave the endpoint unset (stdout); run `make clickstack` and set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` when exporting to HyperDX.
 

--- a/docs/architecture/telemetry.md
+++ b/docs/architecture/telemetry.md
@@ -13,22 +13,24 @@ All telemetry is bootstrapped in `internal/deps/telemetry/`. The server initiali
 | Component      | Status                                                                                                                   |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | Connect RPC    | ✅ — `otelconnect.Interceptor` on all handlers                                                                           |
-| slog → OTel    | ✅ — `otelslog` bridge replaces default logger; with `PUG_OTEL=stdout`, text logs to stdout instead                        |
+| slog → OTel    | ✅ — `otelslog` bridge replaces default logger; with no OTLP endpoint configured, text logs to stdout instead                        |
 | PostgreSQL     | ✅ — `otelpgx` tracer on all connections                                                                                 |
 | Redis          | ✅ — `redisotel` tracing + metrics on the client                                                                         |
 | NATS/JetStream | Custom — `tracedJetStream` wrapper in `internal/deps/nats/otel.go`, W3C trace context propagation on publish/consume     |
 | ClickHouse     | Custom — `Conn` wrapper in `internal/deps/clickhouse/clickhouse.go`, spans on Query/Exec/Select/PrepareBatch/AsyncInsert |
 
-**Configuration:** Set `OTEL_SERVICE_NAME` (strongly recommended — telemetry data will lack a service identifier without it) and `OTEL_EXPORTER_OTLP_ENDPOINT` (default `localhost:4317`). TLS is disabled by default (`OTEL_EXPORTER_OTLP_INSECURE` defaults to `true` when unset); set `OTEL_EXPORTER_OTLP_INSECURE=false` to enable TLS for production OTLP endpoints.
+**Configuration:** Setting an OTLP endpoint is what selects OTLP export (see *Export modes* below) — `OTEL_EXPORTER_OTLP_ENDPOINT` (the conventional collector port is `4317`) or a per-signal `OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_ENDPOINT`. Also set `OTEL_SERVICE_NAME` (strongly recommended — telemetry data will lack a service identifier without it). TLS is disabled by default (`OTEL_EXPORTER_OTLP_INSECURE` defaults to `true` when unset); set `OTEL_EXPORTER_OTLP_INSECURE=false` to enable TLS for production OTLP endpoints.
 
-**`PUG_OTEL` modes:**
+**Export modes (auto-detected):**
 
-| Value | Behavior |
-| ----- | -------- |
-| *(unset)* or `otlp` | OTLP export via `otelslog` (requires a collector; dev default endpoint `localhost:4317`) |
-| `stdout` | Noop providers; text logs on stdout (no collector required) |
+There is no `PUG_OTEL` switch. `SetupSDK` calls `resolveOtelMode()`, which returns `otlp` when `otlpConfigured()` finds an OTLP endpoint var set, otherwise `stdout`:
 
-`PUG_OTEL` is evaluated once per process on the first `SetupSDK` call — set it before starting the server or workers. Any other value fails startup (`ErrInvalidOtelMode`). For local dev with only `make infra`, set `PUG_OTEL=stdout`; run `make clickstack` and use `otlp` (or unset) when exporting to HyperDX.
+| Condition | Behavior |
+| --------- | -------- |
+| Any of `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` / `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` set (non-blank) | OTLP export via `otelslog` (requires a collector) |
+| None set | Noop trace/metric providers; text logs on stdout (no collector required) |
+
+The mode is resolved once per process on the first `SetupSDK` call — set the endpoint var(s) before starting the server or workers. A present-but-blank endpoint (e.g. `OTEL_EXPORTER_OTLP_ENDPOINT=`) counts as unset, so a conditionally-templated empty value can't silently flip pug into exporting at a collector that isn't there. For local dev with only `make infra`, leave the endpoint unset (stdout); run `make clickstack` and set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` when exporting to HyperDX.
 
 **Recording errors in spans:** Use `telemetry.RecordError(ctx, err)` to record an error on the current span, set the span status to `Error`, and attach stack traces.
 

--- a/internal/app/server/rpc/logging_interceptor.go
+++ b/internal/app/server/rpc/logging_interceptor.go
@@ -11,8 +11,9 @@ import (
 	"github.com/pug-sh/pug/internal/slogx"
 )
 
-// LoggingInterceptor logs every RPC request. Since slog is bridged to OTel via
-// otelslog, these log records are automatically exported to the OTel collector.
+// LoggingInterceptor logs every RPC request via slog. With PUG_OTEL=otlp, slog is
+// bridged to OTel (otelslog) and exported to the collector; with PUG_OTEL=stdout,
+// records go to stdout as text.
 func LoggingInterceptor() connect.Interceptor {
 	return &loggingInterceptor{}
 }

--- a/internal/app/server/rpc/logging_interceptor.go
+++ b/internal/app/server/rpc/logging_interceptor.go
@@ -11,9 +11,9 @@ import (
 	"github.com/pug-sh/pug/internal/slogx"
 )
 
-// LoggingInterceptor logs every RPC request via slog. With PUG_OTEL=otlp, slog is
-// bridged to OTel (otelslog) and exported to the collector; with PUG_OTEL=stdout,
-// records go to stdout as text.
+// LoggingInterceptor logs every RPC request via slog. When an OTLP endpoint is
+// configured, slog is bridged to OTel (otelslog) and exported to the collector;
+// otherwise records go to stdout as text.
 func LoggingInterceptor() connect.Interceptor {
 	return &loggingInterceptor{}
 }

--- a/internal/deps/telemetry/correlation_slog.go
+++ b/internal/deps/telemetry/correlation_slog.go
@@ -24,11 +24,12 @@ func (h *correlationHandler) Enabled(ctx context.Context, l slog.Level) bool {
 func (h *correlationHandler) Handle(ctx context.Context, r slog.Record) error {
 	// error_id mirrors the key returned in API error responses, so a user-reported
 	// id cross-references directly to these logs. trace_id is stamped as a record
-	// attr so it survives if the inner handler is ever a plain text handler with no
-	// native trace correlation; with today's otelslog inner handler the attr is
-	// redundant with the SDK-set native trace id in OTLP — harmless, but not
-	// OTLP-free as the layering might suggest. (The shutdown fallback text handler
-	// in otel.go is not wrapped by this handler, so it does not receive these attrs.)
+	// attr because in stdout mode (no OTLP endpoint configured) the inner handler is
+	// a plain slog text handler with no native trace correlation, so this attr is the
+	// only way the trace id reaches the log. Under the otelslog inner handler (OTLP
+	// mode) it is redundant with the SDK-set native trace id — harmless. (The
+	// shutdown fallback text handler in otel.go is not wrapped by this handler, so it
+	// does not receive these attrs.)
 	if id := correlation.IDFromContext(ctx); id != "" {
 		r.AddAttrs(slog.String("error_id", id))
 	}

--- a/internal/deps/telemetry/otel.go
+++ b/internal/deps/telemetry/otel.go
@@ -35,8 +35,9 @@ var (
 // context with a live deadline; the cached result is reused for the rest of the
 // process lifetime.
 //
-// On failure, returns a non-nil error and a nil shutdown function — do not
-// invoke shutdown when err != nil.
+// On failure (only the OTLP path can fail, during exporter/provider init; the
+// stdout path is infallible), returns a non-nil error and a nil shutdown
+// function — do not invoke shutdown when err != nil.
 //
 // The export mode is detected from the standard OTLP endpoint environment
 // variables on the first call only (sync.Once): a configured OTLP endpoint

--- a/internal/deps/telemetry/otel.go
+++ b/internal/deps/telemetry/otel.go
@@ -35,26 +35,20 @@ var (
 // context with a live deadline; the cached result is reused for the rest of the
 // process lifetime.
 //
-// On failure (including invalid PUG_OTEL), returns a non-nil error and a nil
-// shutdown function — do not invoke shutdown when err != nil.
+// On failure, returns a non-nil error and a nil shutdown function — do not
+// invoke shutdown when err != nil.
 //
-// PUG_OTEL is read only on the first call (sync.Once); set it in the process
-// environment before starting the server or any worker.
+// The export mode is detected from the standard OTLP endpoint environment
+// variables on the first call only (sync.Once): a configured OTLP endpoint
+// selects OTLP export, otherwise telemetry logs to stdout. Set those vars in
+// the process environment before starting the server or any worker.
 func SetupSDK(ctx context.Context) (func(context.Context) error, error) {
 	setupOnce.Do(func() {
-		mode, err := parseOtelMode()
-		if err != nil {
-			setupErr = errors.Join(ErrInvalidOtelMode, err)
-			return
-		}
-		switch mode {
-		case "stdout":
-			setupResult, setupErr = doSetupWithoutExport(ctx)
+		switch resolveOtelMode() {
 		case "otlp":
 			setupResult, setupErr = doSetupSDK(ctx)
-		default:
-			// parseOtelMode only returns "otlp" or "stdout"; unreachable.
-			setupErr = errors.Join(ErrInvalidOtelMode, errors.New("unsupported telemetry mode"))
+		default: // "stdout"
+			setupResult, setupErr = doSetupWithoutExport(ctx)
 		}
 	})
 	return setupResult, setupErr
@@ -108,6 +102,7 @@ func doSetupSDK(ctx context.Context) (func(context.Context) error, error) {
 	slog.SetDefault(slog.New(newCorrelationHandler(
 		otelslog.NewHandler(serviceName, otelslog.WithLoggerProvider(loggerProvider), otelslog.WithSource(true)),
 	)))
+	slog.InfoContext(ctx, "OTLP endpoint configured; exporting telemetry via OTLP")
 
 	success = true
 	return onceShutdown(func(ctx context.Context) error {

--- a/internal/deps/telemetry/otel.go
+++ b/internal/deps/telemetry/otel.go
@@ -34,9 +34,28 @@ var (
 // shutdown succeeded. The first caller's context governs the shutdown, so pass a
 // context with a live deadline; the cached result is reused for the rest of the
 // process lifetime.
+//
+// On failure (including invalid PUG_OTEL), returns a non-nil error and a nil
+// shutdown function — do not invoke shutdown when err != nil.
+//
+// PUG_OTEL is read only on the first call (sync.Once); set it in the process
+// environment before starting the server or any worker.
 func SetupSDK(ctx context.Context) (func(context.Context) error, error) {
 	setupOnce.Do(func() {
-		setupResult, setupErr = doSetupSDK(ctx)
+		mode, err := parseOtelMode()
+		if err != nil {
+			setupErr = errors.Join(ErrInvalidOtelMode, err)
+			return
+		}
+		switch mode {
+		case "stdout":
+			setupResult, setupErr = doSetupWithoutExport(ctx)
+		case "otlp":
+			setupResult, setupErr = doSetupSDK(ctx)
+		default:
+			// parseOtelMode only returns "otlp" or "stdout"; unreachable.
+			setupErr = errors.Join(ErrInvalidOtelMode, errors.New("unsupported telemetry mode"))
+		}
 	})
 	return setupResult, setupErr
 }

--- a/internal/deps/telemetry/otel_test.go
+++ b/internal/deps/telemetry/otel_test.go
@@ -2,19 +2,10 @@ package telemetry
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"log/slog"
 	"testing"
 	"time"
 )
-
-func TestErrInvalidOtelMode(t *testing.T) {
-	err := errors.Join(ErrInvalidOtelMode, fmt.Errorf("invalid PUG_OTEL %q: want otlp or stdout", "bad"))
-	if !errors.Is(err, ErrInvalidOtelMode) {
-		t.Fatal("expected errors.Is(err, ErrInvalidOtelMode)")
-	}
-}
 
 func TestInstallStdoutLogHandler_wrapsCorrelationHandler(t *testing.T) {
 	installStdoutLogHandler()

--- a/internal/deps/telemetry/otel_test.go
+++ b/internal/deps/telemetry/otel_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestInstallStdoutLogHandler_wrapsCorrelationHandler(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
 	installStdoutLogHandler()
 	if _, ok := slog.Default().Handler().(*correlationHandler); !ok {
 		t.Fatalf("handler type = %T, want *correlationHandler", slog.Default().Handler())

--- a/internal/deps/telemetry/otel_test.go
+++ b/internal/deps/telemetry/otel_test.go
@@ -2,9 +2,26 @@ package telemetry
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log/slog"
 	"testing"
 	"time"
 )
+
+func TestErrInvalidOtelMode(t *testing.T) {
+	err := errors.Join(ErrInvalidOtelMode, fmt.Errorf("invalid PUG_OTEL %q: want otlp or stdout", "bad"))
+	if !errors.Is(err, ErrInvalidOtelMode) {
+		t.Fatal("expected errors.Is(err, ErrInvalidOtelMode)")
+	}
+}
+
+func TestInstallStdoutLogHandler_wrapsCorrelationHandler(t *testing.T) {
+	installStdoutLogHandler()
+	if _, ok := slog.Default().Handler().(*correlationHandler); !ok {
+		t.Fatalf("handler type = %T, want *correlationHandler", slog.Default().Handler())
+	}
+}
 
 func TestShutdownContextPreservesDeadline(t *testing.T) {
 	parent := context.Background()

--- a/internal/deps/telemetry/sdk_config.go
+++ b/internal/deps/telemetry/sdk_config.go
@@ -2,31 +2,50 @@ package telemetry
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"log/slog"
 	"os"
 	"strings"
 
-	lognoop "go.opentelemetry.io/otel/log/noop"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/log/global"
+	lognoop "go.opentelemetry.io/otel/log/noop"
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
 )
 
-// parseOtelMode reads PUG_OTEL. Unset or "otlp" selects OTLP export; "stdout"
-// skips export and writes application logs to stdout. Returns an error for any other value.
-func parseOtelMode() (string, error) {
-	raw := strings.ToLower(strings.TrimSpace(os.Getenv("PUG_OTEL")))
-	switch raw {
-	case "", "otlp":
-		return "otlp", nil
-	case "stdout":
-		return "stdout", nil
-	default:
-		return "", fmt.Errorf("invalid PUG_OTEL %q: want otlp or stdout", os.Getenv("PUG_OTEL"))
+// otlpEndpointEnvVars are the standard OpenTelemetry environment variables that
+// point the SDK's exporters at a collector. Their presence is how pug decides
+// whether to export via OTLP; with none set, telemetry falls back to stdout.
+var otlpEndpointEnvVars = []string{
+	"OTEL_EXPORTER_OTLP_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+}
+
+// otlpConfigured reports whether the environment points the OTel SDK at a
+// collector — i.e. whether OTLP export is wanted. It is true when any
+// otlpEndpointEnvVars entry holds a non-empty value; a present-but-blank var
+// (e.g. OTEL_EXPORTER_OTLP_ENDPOINT=) is treated as unset so a conditionally
+// templated empty value can't flip pug into exporting at a collector that
+// isn't there.
+func otlpConfigured() bool {
+	for _, name := range otlpEndpointEnvVars {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			return true
+		}
 	}
+	return false
+}
+
+// resolveOtelMode selects the telemetry export mode from the environment with no
+// pug-specific switch: "otlp" when an OTLP endpoint is configured, "stdout"
+// otherwise.
+func resolveOtelMode() string {
+	if otlpConfigured() {
+		return "otlp"
+	}
+	return "stdout"
 }
 
 func doSetupWithoutExport(ctx context.Context) (func(context.Context) error, error) {
@@ -36,7 +55,7 @@ func doSetupWithoutExport(ctx context.Context) (func(context.Context) error, err
 	global.SetLoggerProvider(lognoop.NewLoggerProvider())
 
 	installStdoutLogHandler()
-	slog.InfoContext(ctx, "PUG_OTEL=stdout; application logs on stdout (OTLP export off)")
+	slog.InfoContext(ctx, "no OTLP endpoint configured; application logs on stdout (OTLP export off)")
 
 	return func(context.Context) error { return nil }, nil
 }
@@ -45,6 +64,3 @@ func installStdoutLogHandler() {
 	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{AddSource: true})
 	slog.SetDefault(slog.New(newCorrelationHandler(handler)))
 }
-
-// ErrInvalidOtelMode is returned by SetupSDK when PUG_OTEL is set to an unsupported value.
-var ErrInvalidOtelMode = errors.New("invalid PUG_OTEL")

--- a/internal/deps/telemetry/sdk_config.go
+++ b/internal/deps/telemetry/sdk_config.go
@@ -1,0 +1,50 @@
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	lognoop "go.opentelemetry.io/otel/log/noop"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/log/global"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+)
+
+// parseOtelMode reads PUG_OTEL. Unset or "otlp" selects OTLP export; "stdout"
+// skips export and writes application logs to stdout. Returns an error for any other value.
+func parseOtelMode() (string, error) {
+	raw := strings.ToLower(strings.TrimSpace(os.Getenv("PUG_OTEL")))
+	switch raw {
+	case "", "otlp":
+		return "otlp", nil
+	case "stdout":
+		return "stdout", nil
+	default:
+		return "", fmt.Errorf("invalid PUG_OTEL %q: want otlp or stdout", os.Getenv("PUG_OTEL"))
+	}
+}
+
+func doSetupWithoutExport(ctx context.Context) (func(context.Context) error, error) {
+	otel.SetTextMapPropagator(newPropagator())
+	otel.SetTracerProvider(tracenoop.NewTracerProvider())
+	otel.SetMeterProvider(metricnoop.NewMeterProvider())
+	global.SetLoggerProvider(lognoop.NewLoggerProvider())
+
+	installStdoutLogHandler()
+	slog.InfoContext(ctx, "PUG_OTEL=stdout; application logs on stdout (OTLP export off)")
+
+	return func(context.Context) error { return nil }, nil
+}
+
+func installStdoutLogHandler() {
+	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{AddSource: true})
+	slog.SetDefault(slog.New(newCorrelationHandler(handler)))
+}
+
+// ErrInvalidOtelMode is returned by SetupSDK when PUG_OTEL is set to an unsupported value.
+var ErrInvalidOtelMode = errors.New("invalid PUG_OTEL")

--- a/internal/deps/telemetry/sdk_config_test.go
+++ b/internal/deps/telemetry/sdk_config_test.go
@@ -1,0 +1,40 @@
+package telemetry
+
+import (
+	"testing"
+)
+
+func TestParseOtelMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     string
+		want    string
+		wantErr bool
+	}{
+		{name: "unset defaults otlp", env: "", want: "otlp"},
+		{name: "otlp explicit", env: "otlp", want: "otlp"},
+		{name: "stdout", env: "stdout", want: "stdout"},
+		{name: "stdout uppercase", env: "STDOUT", want: "stdout"},
+		{name: "invalid local", env: "local", wantErr: true},
+		{name: "invalid", env: "file", wantErr: true},
+		{name: "typo", env: "stdou", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PUG_OTEL", tt.env)
+			got, err := parseOtelMode()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseOtelMode: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseOtelMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/deps/telemetry/sdk_config_test.go
+++ b/internal/deps/telemetry/sdk_config_test.go
@@ -1,7 +1,12 @@
 package telemetry
 
 import (
+	"context"
+	"log/slog"
 	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/log/global"
 )
 
 const (
@@ -32,6 +37,7 @@ func TestResolveOtelMode(t *testing.T) {
 		{name: "metrics endpoint only -> otlp", set: map[string]string{envOTLPMetricsEndpoint: "collector:4317"}, want: "otlp"},
 		{name: "logs endpoint only -> otlp", set: map[string]string{envOTLPLogsEndpoint: "collector:4317"}, want: "otlp"},
 		{name: "whitespace-only endpoint -> stdout", set: map[string]string{envOTLPEndpoint: "   "}, want: "stdout"},
+		{name: "blank general + set traces -> otlp", set: map[string]string{envOTLPEndpoint: "", envOTLPTracesEndpoint: "collector:4317"}, want: "otlp"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -54,5 +60,37 @@ func TestResolveOtelModeIgnoresPugOtel(t *testing.T) {
 	t.Setenv("PUG_OTEL", "stdout")
 	if got := resolveOtelMode(); got != "otlp" {
 		t.Fatalf("resolveOtelMode() = %q, want otlp (PUG_OTEL must be ignored)", got)
+	}
+}
+
+// TestDoSetupWithoutExport_installsNoopProviders pins the load-bearing guarantee
+// of the stdout branch: with no OTLP endpoint, the global providers are noop so a
+// collector-less deploy never attempts to export. Asserting the tracer does not
+// record (rather than its concrete type) keeps the check refactor-resilient.
+func TestDoSetupWithoutExport_installsNoopProviders(t *testing.T) {
+	prevTracer := otel.GetTracerProvider()
+	prevMeter := otel.GetMeterProvider()
+	prevLogger := global.GetLoggerProvider()
+	prevSlog := slog.Default()
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prevTracer)
+		otel.SetMeterProvider(prevMeter)
+		global.SetLoggerProvider(prevLogger)
+		slog.SetDefault(prevSlog)
+	})
+
+	shutdown, err := doSetupWithoutExport(context.Background())
+	if err != nil {
+		t.Fatalf("doSetupWithoutExport: %v", err)
+	}
+
+	_, span := otel.Tracer("test").Start(context.Background(), "s")
+	if span.IsRecording() {
+		t.Error("tracer provider is recording; want noop")
+	}
+	span.End()
+
+	if err := shutdown(context.Background()); err != nil {
+		t.Errorf("noop shutdown returned error: %v", err)
 	}
 }

--- a/internal/deps/telemetry/sdk_config_test.go
+++ b/internal/deps/telemetry/sdk_config_test.go
@@ -4,37 +4,55 @@ import (
 	"testing"
 )
 
-func TestParseOtelMode(t *testing.T) {
+const (
+	envOTLPEndpoint        = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	envOTLPTracesEndpoint  = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+	envOTLPMetricsEndpoint = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
+	envOTLPLogsEndpoint    = "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"
+)
+
+// clearOTLPEndpointEnv makes the test hermetic regardless of the ambient
+// environment by clearing every endpoint var the detector consults.
+func clearOTLPEndpointEnv(t *testing.T) {
+	t.Helper()
+	for _, v := range []string{envOTLPEndpoint, envOTLPTracesEndpoint, envOTLPMetricsEndpoint, envOTLPLogsEndpoint} {
+		t.Setenv(v, "")
+	}
+}
+
+func TestResolveOtelMode(t *testing.T) {
 	tests := []struct {
-		name    string
-		env     string
-		want    string
-		wantErr bool
+		name string
+		set  map[string]string
+		want string
 	}{
-		{name: "unset defaults otlp", env: "", want: "otlp"},
-		{name: "otlp explicit", env: "otlp", want: "otlp"},
-		{name: "stdout", env: "stdout", want: "stdout"},
-		{name: "stdout uppercase", env: "STDOUT", want: "stdout"},
-		{name: "invalid local", env: "local", wantErr: true},
-		{name: "invalid", env: "file", wantErr: true},
-		{name: "typo", env: "stdou", wantErr: true},
+		{name: "no endpoint configured -> stdout", set: nil, want: "stdout"},
+		{name: "general endpoint -> otlp", set: map[string]string{envOTLPEndpoint: "localhost:4317"}, want: "otlp"},
+		{name: "traces endpoint only -> otlp", set: map[string]string{envOTLPTracesEndpoint: "collector:4317"}, want: "otlp"},
+		{name: "metrics endpoint only -> otlp", set: map[string]string{envOTLPMetricsEndpoint: "collector:4317"}, want: "otlp"},
+		{name: "logs endpoint only -> otlp", set: map[string]string{envOTLPLogsEndpoint: "collector:4317"}, want: "otlp"},
+		{name: "whitespace-only endpoint -> stdout", set: map[string]string{envOTLPEndpoint: "   "}, want: "stdout"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("PUG_OTEL", tt.env)
-			got, err := parseOtelMode()
-			if tt.wantErr {
-				if err == nil {
-					t.Fatal("expected error")
-				}
-				return
+			clearOTLPEndpointEnv(t)
+			for k, v := range tt.set {
+				t.Setenv(k, v)
 			}
-			if err != nil {
-				t.Fatalf("parseOtelMode: %v", err)
-			}
-			if got != tt.want {
-				t.Fatalf("parseOtelMode() = %q, want %q", got, tt.want)
+			if got := resolveOtelMode(); got != tt.want {
+				t.Fatalf("resolveOtelMode() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestResolveOtelModeIgnoresPugOtel locks in the removal of the PUG_OTEL switch:
+// mode selection must derive solely from the standard OTLP endpoint env vars.
+func TestResolveOtelModeIgnoresPugOtel(t *testing.T) {
+	clearOTLPEndpointEnv(t)
+	t.Setenv(envOTLPEndpoint, "localhost:4317")
+	t.Setenv("PUG_OTEL", "stdout")
+	if got := resolveOtelMode(); got != "otlp" {
+		t.Fatalf("resolveOtelMode() = %q, want otlp (PUG_OTEL must be ignored)", got)
 	}
 }


### PR DESCRIPTION
When PUG_OTEL=stdout, slog writes text to stdout with noop trace export; docs and examples document otlp vs stdout for local dev and production.