### PR TITLE
feat: add liveness and readiness health probes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ fmt:
 
 .PHONY: test
 test:
-	go test ./... -count=1
+	go test ./... -race -count=1
 
 .PHONY: psql
 psql:

--- a/internal/app/server/deps.go
+++ b/internal/app/server/deps.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"connectrpc.com/otelconnect"
@@ -28,6 +29,11 @@ type deps struct {
 	pgW             *pgxpool.Pool
 	redis           *redis.Client
 	port            string
+
+	// readyFailures counts consecutive failed readiness probes. It distinguishes
+	// a transient blip (logged at WARN) from a sustained outage (escalated to
+	// error telemetry); see (*deps).recordReadiness in health.go.
+	readyFailures atomic.Int64
 }
 
 // close shuts down all deps. OTel must shut down last — it owns the slog backend,

--- a/internal/app/server/health.go
+++ b/internal/app/server/health.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+)
+
+var errNATSNotConnected = errors.New("nats connection not established")
+
+// readinessTimeout bounds the total time spent pinging dependencies so a hung
+// dependency can't make the probe itself hang.
+const readinessTimeout = 2 * time.Second
+
+// livenessHandler answers Kubernetes liveness probes. It reports only that the
+// process is up and serving — it deliberately does NOT check dependencies, so a
+// transient dependency blip can't trigger a restart cascade across replicas.
+func livenessHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+// readinessHandler answers Kubernetes readiness probes by pinging every backing
+// dependency. A failure returns 503 so the pod is pulled from the Service
+// endpoints (stops receiving traffic) without being killed.
+func (d *deps) readinessHandler(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), readinessTimeout)
+	defer cancel()
+
+	writeReadiness(ctx, w, map[string]func(context.Context) error{
+		"postgres_writer": d.pgW.Ping,
+		"postgres_reader": d.pgRo.Ping,
+		"clickhouse":      d.ch.Ping,
+		"redis":           d.redis.Ping,
+		"nats": func(context.Context) error {
+			if !d.nats.IsConnected() {
+				return errNATSNotConnected
+			}
+			return nil
+		},
+	})
+}
+
+// writeReadiness runs every dependency check and writes the probe response: 200
+// with all deps "ok", or 503 if any fails. Checks run concurrently so each gets
+// the full timeout independently — one slow dependency must not consume the
+// budget of the others and make healthy deps report a misleading deadline error.
+func writeReadiness(ctx context.Context, w http.ResponseWriter, checks map[string]func(context.Context) error) {
+	var mu sync.Mutex
+	// statuses is the public response body ("ok"/"unavailable" only); failures
+	// holds the underlying errors for the operator log. The error strings are
+	// kept off the wire so /readyz can't leak internal hosts/ports to callers.
+	statuses := make(map[string]string, len(checks))
+	failures := make(map[string]string)
+	ready := true
+
+	var wg sync.WaitGroup
+	for name, check := range checks {
+		wg.Go(func() {
+			err := check(ctx)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				ready = false
+				statuses[name] = "unavailable"
+				failures[name] = err.Error()
+				return
+			}
+			statuses[name] = "ok"
+		})
+	}
+	wg.Wait()
+
+	status := http.StatusOK
+	if !ready {
+		status = http.StatusServiceUnavailable
+		// Routine operational signal, not an exception — log without
+		// telemetry.RecordError to avoid polluting error metrics on every
+		// dependency blip.
+		slog.WarnContext(ctx, "readiness probe failed", slog.Any("dependencies", failures))
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"ready":        ready,
+		"dependencies": statuses,
+	})
+}

--- a/internal/app/server/health.go
+++ b/internal/app/server/health.go
@@ -4,17 +4,28 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/pug-sh/pug/internal/deps/telemetry"
 )
 
 var errNATSNotConnected = errors.New("nats connection not established")
 
 // readinessTimeout bounds the total time spent pinging dependencies so a hung
-// dependency can't make the probe itself hang.
+// dependency can't make the probe itself hang. Keep it ≤ the readiness probe's
+// timeoutSeconds in the Deployment manifest (pug-sh/gitops) so the two deadlines
+// don't drift apart.
 const readinessTimeout = 2 * time.Second
+
+// readinessFailureAlertThreshold is the number of consecutive failing probes at
+// which a readiness failure stops being treated as a transient blip and is
+// escalated to ERROR-severity logging. Wall-clock to escalation is this count
+// times the probe's periodSeconds in that Deployment manifest.
+const readinessFailureAlertThreshold = 5
 
 // livenessHandler answers Kubernetes liveness probes. It reports only that the
 // process is up and serving — it deliberately does NOT check dependencies, so a
@@ -32,7 +43,7 @@ func (d *deps) readinessHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), readinessTimeout)
 	defer cancel()
 
-	writeReadiness(ctx, w, map[string]func(context.Context) error{
+	ready, failures := writeReadiness(ctx, w, map[string]func(context.Context) error{
 		"postgres_writer": d.pgW.Ping,
 		"postgres_reader": d.pgRo.Ping,
 		"clickhouse":      d.ch.Ping,
@@ -44,13 +55,19 @@ func (d *deps) readinessHandler(w http.ResponseWriter, r *http.Request) {
 			return nil
 		},
 	})
+
+	d.recordReadiness(ctx, ready, failures)
 }
 
 // writeReadiness runs every dependency check and writes the probe response: 200
-// with all deps "ok", or 503 if any fails. Checks run concurrently so each gets
-// the full timeout independently — one slow dependency must not consume the
-// budget of the others and make healthy deps report a misleading deadline error.
-func writeReadiness(ctx context.Context, w http.ResponseWriter, checks map[string]func(context.Context) error) {
+// with all deps "ok", or 503 if any fails. Checks run concurrently against a
+// single shared deadline (the ctx passed in), so total probe latency is bounded
+// by the slowest dependency rather than the sum of all of them — a slow check
+// can't serialize ahead of the others and starve them of their budget. It returns
+// the overall readiness and the per-dependency failures (the underlying error
+// strings, operator-only) so the caller can log/escalate without re-running the
+// checks.
+func writeReadiness(ctx context.Context, w http.ResponseWriter, checks map[string]func(context.Context) error) (bool, map[string]string) {
 	var mu sync.Mutex
 	// statuses is the public response body ("ok"/"unavailable" only); failures
 	// holds the underlying errors for the operator log. The error strings are
@@ -79,10 +96,6 @@ func writeReadiness(ctx context.Context, w http.ResponseWriter, checks map[strin
 	status := http.StatusOK
 	if !ready {
 		status = http.StatusServiceUnavailable
-		// Routine operational signal, not an exception — log without
-		// telemetry.RecordError to avoid polluting error metrics on every
-		// dependency blip.
-		slog.WarnContext(ctx, "readiness probe failed", slog.Any("dependencies", failures))
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -91,4 +104,40 @@ func writeReadiness(ctx context.Context, w http.ResponseWriter, checks map[strin
 		"ready":        ready,
 		"dependencies": statuses,
 	})
+
+	return ready, failures
+}
+
+// recordReadiness logs the outcome of a readiness probe and escalates a sustained
+// outage. A one-off failure is a routine operational signal (WARN) so a transient
+// dependency blip doesn't pollute error telemetry. Once failures persist for
+// readinessFailureAlertThreshold consecutive probes the outage is no longer a
+// blip: it escalates to slog.ErrorContext — exported at ERROR severity via the
+// otelslog bridge — so a fleet stuck NotReady can't drain from its Service with
+// only WARN noise to show for it. It stays escalated for the duration (not just
+// at the transition) so the signal can't age out while the outage continues; a
+// single healthy probe resets the counter.
+//
+// RecordError is paired with the ErrorContext per the house convention, but
+// /readyz is mounted outside the RPC interceptor chain and so runs under no OTel
+// span: RecordError is a no-op on this route today (the exported ERROR log is the
+// live signal) and only starts contributing if the route is ever given a span.
+// Its message omits the failing dependency names so errors would group cleanly;
+// the per-dependency detail rides on the structured log instead.
+func (d *deps) recordReadiness(ctx context.Context, ready bool, failures map[string]string) {
+	if ready {
+		d.readyFailures.Store(0)
+		return
+	}
+
+	n := d.readyFailures.Add(1)
+	if n >= readinessFailureAlertThreshold {
+		err := fmt.Errorf("readiness probe failing for %d consecutive checks", n)
+		telemetry.RecordError(ctx, err)
+		slog.ErrorContext(ctx, "readiness probe failing persistently",
+			slog.Int64("consecutive_failures", n), slog.Any("dependencies", failures))
+		return
+	}
+
+	slog.WarnContext(ctx, "readiness probe failed", slog.Any("dependencies", failures))
 }

--- a/internal/app/server/health_test.go
+++ b/internal/app/server/health_test.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWriteReadiness(t *testing.T) {
+	okCheck := func(context.Context) error { return nil }
+	failCheck := func(context.Context) error { return errors.New("dial tcp 10.0.70.104:6432: connection refused") }
+
+	tests := map[string]struct {
+		checks         map[string]func(context.Context) error
+		wantStatus     int
+		wantReady      bool
+		wantStatuses   map[string]string
+		wantNoErrorStr bool // body must never carry the underlying error string
+	}{
+		"all healthy": {
+			checks:       map[string]func(context.Context) error{"redis": okCheck, "nats": okCheck},
+			wantStatus:   http.StatusOK,
+			wantReady:    true,
+			wantStatuses: map[string]string{"redis": "ok", "nats": "ok"},
+		},
+		"one dependency down": {
+			checks:         map[string]func(context.Context) error{"redis": okCheck, "postgres_writer": failCheck},
+			wantStatus:     http.StatusServiceUnavailable,
+			wantReady:      false,
+			wantStatuses:   map[string]string{"redis": "ok", "postgres_writer": "unavailable"},
+			wantNoErrorStr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			writeReadiness(context.Background(), rec, tc.checks)
+
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+
+			var body struct {
+				Ready        bool              `json:"ready"`
+				Dependencies map[string]string `json:"dependencies"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body.Ready != tc.wantReady {
+				t.Errorf("ready = %v, want %v", body.Ready, tc.wantReady)
+			}
+			for dep, want := range tc.wantStatuses {
+				if got := body.Dependencies[dep]; got != want {
+					t.Errorf("dependencies[%q] = %q, want %q", dep, got, want)
+				}
+			}
+			if tc.wantNoErrorStr && bodyLeaksInternals(rec.Body.String()) {
+				t.Errorf("response body leaked internal error detail: %s", rec.Body.String())
+			}
+		})
+	}
+}
+
+// bodyLeaksInternals guards the contract that /readyz never puts raw dependency
+// error strings (hosts, ports) on the wire.
+func bodyLeaksInternals(body string) bool {
+	for _, leak := range []string{"10.0.70", "connection refused", "dial tcp"} {
+		if strings.Contains(body, leak) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/server/health_test.go
+++ b/internal/app/server/health_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestWriteReadiness(t *testing.T) {
@@ -60,10 +61,97 @@ func TestWriteReadiness(t *testing.T) {
 					t.Errorf("dependencies[%q] = %q, want %q", dep, got, want)
 				}
 			}
+			// Exhaustiveness: every check must report exactly once. A subset
+			// assertion would miss a dependency silently dropped from the body
+			// (e.g. a check that returns before recording its status), which
+			// would mean a backend is no longer probed while /readyz still 200s.
+			if len(body.Dependencies) != len(tc.checks) {
+				t.Errorf("dependencies count = %d, want %d (a check was dropped or duplicated)", len(body.Dependencies), len(tc.checks))
+			}
 			if tc.wantNoErrorStr && bodyLeaksInternals(rec.Body.String()) {
 				t.Errorf("response body leaked internal error detail: %s", rec.Body.String())
 			}
 		})
+	}
+}
+
+// TestWriteReadinessTimeout pins the core reason the probe fans out concurrently:
+// a dependency that blocks until the deadline must not hang the probe or starve a
+// healthy dependency running alongside it.
+func TestWriteReadinessTimeout(t *testing.T) {
+	hangCheck := func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	okCheck := func(context.Context) error { return nil }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	rec := httptest.NewRecorder()
+	ready, failures := writeReadiness(ctx, rec, map[string]func(context.Context) error{
+		"slow":  hangCheck,
+		"redis": okCheck,
+	})
+
+	if ready {
+		t.Error("ready = true, want false when a dependency exceeds the deadline")
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+
+	var body struct {
+		Ready        bool              `json:"ready"`
+		Dependencies map[string]string `json:"dependencies"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got := body.Dependencies["slow"]; got != "unavailable" {
+		t.Errorf("dependencies[slow] = %q, want unavailable", got)
+	}
+	if got := body.Dependencies["redis"]; got != "ok" {
+		t.Errorf("dependencies[redis] = %q, want ok — healthy dep was starved by the slow one", got)
+	}
+	if _, ok := failures["slow"]; !ok {
+		t.Error("failures must record the timed-out dependency for the operator log")
+	}
+}
+
+// TestRecordReadiness covers the consecutive-failure state machine: failures
+// increment the streak, crossing the threshold takes the escalation branch
+// without panicking (RecordError is a no-op absent an active span), and a single
+// healthy probe resets the streak. It does not assert that telemetry.RecordError
+// fired — that would need a telemetry seam this package doesn't expose.
+func TestRecordReadiness(t *testing.T) {
+	d := &deps{}
+	failures := map[string]string{"redis": "connection refused"}
+
+	for i := 1; i < readinessFailureAlertThreshold; i++ {
+		d.recordReadiness(context.Background(), false, failures)
+		if got := d.readyFailures.Load(); got != int64(i) {
+			t.Fatalf("after %d consecutive failures, counter = %d, want %d", i, got, i)
+		}
+	}
+
+	// Crossing into the escalation branch must still just count.
+	d.recordReadiness(context.Background(), false, failures)
+	if got := d.readyFailures.Load(); got != readinessFailureAlertThreshold {
+		t.Fatalf("counter = %d, want %d at the escalation threshold", got, readinessFailureAlertThreshold)
+	}
+
+	// The streak keeps climbing past the threshold: escalation persists for the
+	// duration of the outage (>= threshold), it does not fire once and stall.
+	d.recordReadiness(context.Background(), false, failures)
+	if got := d.readyFailures.Load(); got != readinessFailureAlertThreshold+1 {
+		t.Fatalf("counter = %d, want %d past the escalation threshold", got, readinessFailureAlertThreshold+1)
+	}
+
+	// A single healthy probe resets the streak.
+	d.recordReadiness(context.Background(), true, nil)
+	if got := d.readyFailures.Load(); got != 0 {
+		t.Fatalf("counter after a healthy probe = %d, want 0", got)
 	}
 }
 

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -191,6 +191,11 @@ func start(ctx context.Context, d *deps) error {
 
 	mux := http.NewServeMux()
 
+	// Health probes (no auth, no CORS — infra endpoints). Plain paths do not
+	// collide with the RPC routes, which are all /<package>.<Service>/...
+	mux.HandleFunc("/healthz", livenessHandler)
+	mux.HandleFunc("/readyz", d.readinessHandler)
+
 	// Public (CORS, no auth)
 	mux.Handle(authPath, pogrpc.WithCORS(d.corsOrigins, authHandler))
 	mux.Handle(sharedDashboardsPath, pogrpc.WithCORS(d.corsOrigins, sharedDashboardsHandler))

--- a/internal/deps/nats/client.go
+++ b/internal/deps/nats/client.go
@@ -86,6 +86,12 @@ func New(ctx context.Context) (*NATSClient, error) {
 	}, nil
 }
 
+// IsConnected reports whether the underlying NATS connection is currently
+// established. Used by readiness probes; a closed/reconnecting conn is not ready.
+func (nc *NATSClient) IsConnected() bool {
+	return nc.conn != nil && nc.conn.IsConnected()
+}
+
 // Close closes the NATS connection
 func (nc *NATSClient) Close() {
 	if nc.conn != nil {

--- a/internal/deps/redis/redis.go
+++ b/internal/deps/redis/redis.go
@@ -52,6 +52,11 @@ func NewFromConfig(ctx context.Context, cfg *Config) (*Client, error) {
 	return &Client{client: client}, nil
 }
 
+// Ping verifies connectivity to Redis. Used by readiness probes.
+func (c *Client) Ping(ctx context.Context) error {
+	return c.client.Ping(ctx).Err()
+}
+
 func (c *Client) Close(ctx context.Context) {
 	slog.InfoContext(ctx, "Closing redis connection.")
 	if err := c.client.Close(); err != nil {


### PR DESCRIPTION
Add /healthz (liveness, no dependency checks) and /readyz (readiness, pings postgres/clickhouse/redis/nats concurrently) HTTP endpoints. The readiness body reports only ok/unavailable per dependency; underlying errors go to the operator log to avoid leaking internal hosts/ports.

Adds NATSClient.IsConnected and redis.Client.Ping helpers used by the probe.