### PR TITLE
docs: add community health files and Discord links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces — including the GitHub
+repository and the Pug Discord server — and also applies when an individual is
+officially representing the community in public spaces. Examples of representing
+our community include using an official e-mail address, posting via an official
+social media account, or acting as an appointed representative at an online or
+offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers responsible for enforcement at **hello@pug.sh**,
+or by direct message to a **🦴 Maintainer** on the [Pug Discord](https://discord.gg/kDNHDWcBHP).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to Pug
+
+Thanks for your interest in Pug! 🐶 Pug is an open-source product analytics
+platform, and contributions of every kind are welcome — bug reports, docs,
+features, and questions.
+
+- 💬 **Chat & get help:** [Pug Discord](https://discord.gg/kDNHDWcBHP)
+- 🐛 **Bugs & feature requests:** [GitHub Issues](https://github.com/pug-sh/pug/issues)
+- 📜 **Be kind:** all participation is governed by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Ways to contribute
+
+- **Report a bug** — open an issue with steps to reproduce, your OS, the Pug
+  version/commit, and relevant logs.
+- **Ask a question** — the fastest place is `#help` on [Discord](https://discord.gg/kDNHDWcBHP).
+  Please don't open issues for usage questions.
+- **Propose a change** — for anything non-trivial, open an issue (or start a
+  thread in `#dev` on Discord) to discuss the approach before writing code.
+- **Pick up a good first issue** — look for the
+  [`good first issue`](https://github.com/pug-sh/pug/labels/good%20first%20issue) label.
+
+## Development setup
+
+**Prerequisites:** [Go 1.26+](https://go.dev/dl/) and Docker (with Docker
+Compose) for the local infrastructure.
+
+```bash
+# Install Go tool dependencies (golangci-lint, sqlc, templ, buf via `go tool`)
+make install-go-deps
+
+# Build the binary -> bin/pug
+make build
+
+# Start dev infrastructure (PostgreSQL, ClickHouse, NATS)
+make infra
+
+# Run migrations
+./bin/pug postgres migrate
+./bin/pug nats migrate
+./bin/pug clickhouse migrate
+
+# Start the dev server + workers together
+./bin/pug dev
+```
+
+Environment variables are documented in [`.env.example`](.env.example). Deeper
+architecture notes live in [`docs/architecture/`](docs/architecture/), and
+conventions the codebase follows are in [`CLAUDE.md`](CLAUDE.md) — please skim it
+before your first PR.
+
+## Before you open a pull request
+
+Run these locally — CI (`ci.yaml`, `buf-ci.yaml`) enforces the same:
+
+```bash
+make fmt     # goimports on changed Go files
+make lint    # golangci-lint
+make test    # go test ./... -race
+```
+
+If you changed generated inputs, regenerate and commit the output:
+
+```bash
+make sqlc    # after editing SQL under schema/postgres/queries/
+make rpc     # after editing .proto files
+make templ   # after editing .templ email templates
+```
+
+Do **not** hand-edit anything under `internal/gen/` — it is generated.
+
+## Pull request guidelines
+
+- **Branch** off `main` and keep PRs focused on one change.
+- **Commit messages** follow [Conventional Commits](https://www.conventionalcommits.org/)
+  with a scope, matching the existing history — e.g. `fix(auth): ...`,
+  `feat(insights): ...`, `test(dashboards): ...`, `docs(readme): ...`.
+- **Link the issue** your PR addresses and describe the change and how you tested it.
+- **Keep CI green** and add tests for new behavior (the suite runs with the race
+  detector).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[GNU AGPL v3.0](LICENSE), the same license that covers the project.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/pug-sh/pug/actions/workflows/ci.yaml/badge.svg)](https://github.com/pug-sh/pug/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/pug-sh/pug/branch/main/graph/badge.svg)](https://codecov.io/gh/pug-sh/pug)
+[![Discord](https://img.shields.io/badge/Discord-Join%20chat-5865F2?logo=discord&logoColor=white)](https://discord.gg/kDNHDWcBHP)
 
 Pug is an open-source product analytics platform. Capture events, identify the
 people behind them, and explore behavior through funnels, retention, trends,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported versions
+
+Pug is pre-1.0 and moves fast. Security fixes land on `main` and in the latest
+release; there are no long-term support branches yet. Please confirm you can
+reproduce an issue against the latest `main` before reporting.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+Discord, or any other public channel.**
+
+Report privately via one of:
+
+1. **GitHub private vulnerability reporting** (preferred) — on the
+   [repository's Security tab](https://github.com/pug-sh/pug/security), choose
+   **Report a vulnerability**. This opens a private advisory visible only to you
+   and the maintainers.
+2. **Email** — **dev@pug.sh**.
+
+Please include:
+
+- a description of the vulnerability and its impact,
+- steps to reproduce or a proof of concept,
+- the affected version or commit, and
+- any suggested remediation, if you have one.
+
+## What to expect
+
+- We will acknowledge your report within a few business days.
+- We will keep you updated as we investigate and work on a fix.
+- We will credit you in the advisory once a fix ships, unless you prefer to
+  remain anonymous.
+
+Thank you for helping keep Pug and its users safe.


### PR DESCRIPTION
## What

Adds standard OSS community-health files and wires the new Discord server into the repo.

- CODE_OF_CONDUCT.md — Contributor Covenant 2.1; enforcement via hello@pug.sh (or DM a Maintainer on Discord)
- CONTRIBUTING.md — dev setup (make targets, Go 1.26), Conventional Commits, PR guidelines, Discord links
- SECURITY.md — private vulnerability reporting via GitHub advisories and dev@pug.sh
- README.md — Discord badge

## Follow-ups (not in this PR)

- [ ] Enable Settings → Advanced Security → Private vulnerability reporting so the SECURITY.md preferred path is live
- [ ] Discord server config: roles, channels, onboarding, AutoMod, GitHub webhook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a community code of conduct with behavior standards, reporting guidance, and enforcement steps.
  * Added contributor guidance covering setup, development commands, checks before submitting changes, and pull request expectations.
  * Added a security policy explaining how to report vulnerabilities and what information to include.
  * Updated the project README with a chat/community link badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->