### PR TITLE
refactor(testutil): share one container per package, not per test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,19 @@ PostgreSQL uses read/write separation:
 - SQL syntax and identifiers: lowercase (e.g., `select * from campaigns where project_id = @project_id`)
 - Partial updates: use `coalesce(nullif(@field, ''), field)` to preserve existing values when empty
 
+### Testing
+
+Integration tests run against real Postgres/ClickHouse/NATS/Redis via testcontainers (`internal/testutil`). **Containers are shared per package, not per test** — one per test binary, started lazily on the first `Setup*` call. Isolation is per-test but comes from a namespace inside the shared container, never from a fresh container:
+
+- **`SetupPostgres`** — migrations run **once** into a `pug_template` database; each test gets its own DB via `create database ... template pug_template` (milliseconds, vs seconds for a container start + migration run). `sealTemplate` bars connections to the template afterwards, because `CREATE DATABASE ... TEMPLATE` fails while any session is attached to the source.
+- **`SetupClickHouse`** — ClickHouse has no `TEMPLATE`, so each test gets a fresh database that is migrated on creation.
+- **`SetupNATS`** — JetStream has no per-test namespace, so each call drops every stream (which drops its consumers' ack state too) and recreates them from `schema/nats/*.yaml`.
+- **`SetupRedis`** — each test gets one of the 16 logical databases, flushed on entry and exit.
+
+Every package calling a `Setup*` helper **must** declare `func TestMain(m *testing.M) { testutil.Main(m) }` — the container has no owning test to hang a `t.Cleanup` on, so without it containers outlive the run; `TestSetupCallersWireMain` fails if a package forgets. That teardown only covers a normal finish, so `Main` also **force-enables testcontainers' Ryuk reaper**, overriding a `~/.testcontainers.properties` that disables it: a panicking test, an expired `-timeout` or a Ctrl-C kills the process without `m.Run` ever returning, and Ryuk is the only thing that reaps a package's containers then. Export `TESTCONTAINERS_RYUK_DISABLED` explicitly to opt back out (Ryuk cannot drive every Docker setup). A failed container start is deliberately **not** memoized (`lazyContainer.get`): starts time out when the Docker daemon is saturated, and caching that error would fail every remaining test in the package against a stale message.
+
+Every helper hands out an **empty** namespace, so a test may still assume an empty database — that part of the contract did not change. What the shared container newly forbids is **concurrency**: a package calling a `Setup*` helper must not call `t.Parallel()`. Postgres and ClickHouse would survive it (each test holds a private database), but `SetupNATS` rebuilds streams container-wide and `SetupRedis` recycles its 16 indexes with a flush on entry, so a concurrent test gets its state deleted mid-run — and then either fails somewhere unrelated or passes having asserted over nothing. `TestSetupCallersDoNotUseParallel` fails the build on one. For the same reason a client or goroutine must not outlive the test that created it: the next `Setup*` reclaims the namespace. `go test -short ./...` skips every container test for fast unit-only feedback.
+
 ### Org Hierarchy
 
 - **Org** is the top-level entity. Each customer belongs to one or more orgs via `org_members` (role: `ORG_ROLE_ADMIN` | `ORG_ROLE_MEMBER` | `ORG_ROLE_VIEWER`).

--- a/internal/app/seed/postgres/main_test.go
+++ b/internal/app/seed/postgres/main_test.go
@@ -1,0 +1,11 @@
+package seed_test
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/app/server/rpc/dashboard/customers/main_test.go
+++ b/internal/app/server/rpc/dashboard/customers/main_test.go
@@ -1,0 +1,11 @@
+package customers
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/app/server/rpc/dashboard/dashboards/main_test.go
+++ b/internal/app/server/rpc/dashboard/dashboards/main_test.go
@@ -1,0 +1,11 @@
+package dashboards
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/app/server/rpc/dashboard/orgemailproviders/main_test.go
+++ b/internal/app/server/rpc/dashboard/orgemailproviders/main_test.go
@@ -1,0 +1,11 @@
+package orgemailproviders_test
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/app/server/rpc/dashboard/orgs/main_test.go
+++ b/internal/app/server/rpc/dashboard/orgs/main_test.go
@@ -1,0 +1,11 @@
+package orgs_test
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/app/server/rpc/dashboard/projects/main_test.go
+++ b/internal/app/server/rpc/dashboard/projects/main_test.go
@@ -1,0 +1,11 @@
+package projects
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/app/server/rpc/public/dashboards/main_test.go
+++ b/internal/app/server/rpc/public/dashboards/main_test.go
@@ -1,0 +1,11 @@
+package dashboards
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/app/server/rpc/shared/profiles/main_test.go
+++ b/internal/app/server/rpc/shared/profiles/main_test.go
@@ -1,0 +1,11 @@
+package profiles
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/app/workers/devices/main_test.go
+++ b/internal/app/workers/devices/main_test.go
@@ -1,0 +1,11 @@
+package devices
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/app/workers/email/main_test.go
+++ b/internal/app/workers/email/main_test.go
@@ -1,0 +1,11 @@
+package email
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/app/workers/profiles/identify/main_test.go
+++ b/internal/app/workers/profiles/identify/main_test.go
@@ -1,0 +1,11 @@
+package identify
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/app/workers/profiles/upsert/main_test.go
+++ b/internal/app/workers/profiles/upsert/main_test.go
@@ -1,0 +1,11 @@
+package upsert
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/core/auth/main_test.go
+++ b/internal/core/auth/main_test.go
@@ -1,0 +1,11 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/core/auth/oauth/main_test.go
+++ b/internal/core/auth/oauth/main_test.go
@@ -1,0 +1,11 @@
+package oauth_test
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/core/campaigns/main_test.go
+++ b/internal/core/campaigns/main_test.go
@@ -1,0 +1,11 @@
+package campaigns_test
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/core/customers/main_test.go
+++ b/internal/core/customers/main_test.go
@@ -1,0 +1,11 @@
+package customers_test
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/core/dashboards/main_test.go
+++ b/internal/core/dashboards/main_test.go
@@ -1,0 +1,11 @@
+package dashboards
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/core/devices/main_test.go
+++ b/internal/core/devices/main_test.go
@@ -1,0 +1,11 @@
+package devices_test
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/core/email/main_test.go
+++ b/internal/core/email/main_test.go
@@ -1,0 +1,11 @@
+package email_test
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/core/events/main_test.go
+++ b/internal/core/events/main_test.go
@@ -1,0 +1,11 @@
+package events_test
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/core/insights/main_test.go
+++ b/internal/core/insights/main_test.go
@@ -1,0 +1,11 @@
+package insights_test
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/core/orgs/main_test.go
+++ b/internal/core/orgs/main_test.go
@@ -1,0 +1,11 @@
+package orgs_test
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/core/profiles/main_test.go
+++ b/internal/core/profiles/main_test.go
@@ -1,0 +1,11 @@
+package profiles_test
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/core/projects/main_test.go
+++ b/internal/core/projects/main_test.go
@@ -1,0 +1,11 @@
+package projects_test
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+// TestMain tears down the containers this package's tests share. See
+// testutil.Main.
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/testutil/clickhouse.go
+++ b/internal/testutil/clickhouse.go
@@ -80,7 +80,14 @@ func SetupClickHouse(t *testing.T) *TestClickHouse {
 		// wrong — but without sync every test's tables sit in system.dropped_tables
 		// holding their data, and a package's worth of them accumulates in a container
 		// the whole package shares. sync unlinks before returning.
-		if _, err := sc.admin.ExecContext(context.Background(),
+		//
+		// The timeout is a backstop against a wedged connection hanging the drop
+		// until go test -timeout, not a fail-fast: it is generous so a sync drop
+		// under a loaded daemon has room to finish rather than erroring out and
+		// leaving the data it was meant to unlink (cleanupDropTimeout).
+		dropCtx, cancel := context.WithTimeout(context.Background(), cleanupDropTimeout)
+		defer cancel()
+		if _, err := sc.admin.ExecContext(dropCtx,
 			fmt.Sprintf("drop database if exists %s sync", quoteCH(name))); err != nil {
 			t.Errorf("testutil: drop clickhouse database %s: %v", name, err)
 		}

--- a/internal/testutil/clickhouse.go
+++ b/internal/testutil/clickhouse.go
@@ -3,17 +3,22 @@ package testutil
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
 
+	"github.com/testcontainers/testcontainers-go"
+
 	_ "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/pressly/goose/v3"
+	"github.com/rs/xid"
 	tcclickhouse "github.com/testcontainers/testcontainers-go/modules/clickhouse"
 
 	chq "github.com/pug-sh/pug/internal/core/clickhouse"
@@ -22,87 +27,129 @@ import (
 
 const testClickHouseImage = "clickhouse/clickhouse-server@sha256:a4202d2f7a0c0ac98aca2bda670f5b7278722463c0bdd4c2de5241e8e1e898ed" // 26.5.1.882-alpine
 
-// TestClickHouse holds the container and connection for a test ClickHouse instance.
+// chAdminDB is the container's initial database, used only to issue the
+// CREATE/DROP DATABASE statements for the per-test databases. Tests never read
+// or write it. ClickHouse has no CREATE DATABASE ... TEMPLATE, so unlike
+// Postgres each test database is migrated on creation rather than cloned.
+const chAdminDB = "pug_admin"
+
+// TestClickHouse holds the connection to one test's private database.
 type TestClickHouse struct {
-	container *tcclickhouse.ClickHouseContainer
-	Conn      *chdep.Conn
-	URL       string
+	Conn *chdep.Conn
+	URL  string
 }
 
-// SetupClickHouse starts a ClickHouse container, runs all goose migrations,
-// and returns a connection. Cleanup is registered via t.Cleanup.
+// sharedClickHouse is the single container backing every test in the package.
+type sharedClickHouse struct {
+	admin   *sql.DB
+	connFor func(db string) string
+}
+
+var chContainer = &lazyContainer[sharedClickHouse]{kind: "clickhouse", start: startClickHouse}
+
+// SetupClickHouse starts (or reuses) the package's ClickHouse container, then
+// creates and migrates a database private to this test. Cleanup is registered
+// via t.Cleanup; the container is torn down by Main.
 func SetupClickHouse(t *testing.T) *TestClickHouse {
 	t.Helper()
-	ctx := context.Background()
+	// Scoped to the test — see the note in SetupPostgres for why the shared
+	// container and the cleanup below use context.Background instead.
+	ctx := t.Context()
 
-	ctr, err := tcclickhouse.Run(ctx, testClickHouseImage,
-		tcclickhouse.WithDatabase("pug_test"),
-		tcclickhouse.WithUsername("default"),
-		tcclickhouse.WithPassword("test"),
-	)
-	if err != nil {
-		t.Fatalf("testutil: start clickhouse container: %v", err)
+	sc := chContainer.get(t)
+
+	name := "test_" + xid.New().String()
+	if _, err := sc.admin.ExecContext(ctx, fmt.Sprintf("create database %s", quoteCH(name))); err != nil {
+		t.Fatalf("testutil: create clickhouse database: %v", err)
 	}
 
-	connStr, err := ctr.ConnectionString(ctx)
-	if err != nil {
-		_ = ctr.Terminate(ctx)
-		t.Fatalf("testutil: get clickhouse connection string: %v", err)
-	}
-
-	if err := migrateClickHouse(ctx, connStr); err != nil {
-		_ = ctr.Terminate(ctx)
+	dsn := sc.connFor(name)
+	if err := migrateClickHouse(ctx, dsn); err != nil {
 		t.Fatalf("testutil: run clickhouse migrations: %v", err)
 	}
 
-	chConn, err := chdep.NewReaderPool(ctx, &chdep.Config{URL: connStr})
+	conn, err := chdep.NewReaderPool(ctx, &chdep.Config{URL: dsn})
 	if err != nil {
-		_ = ctr.Terminate(ctx)
 		t.Fatalf("testutil: create clickhouse connection: %v", err)
 	}
 
-	tc := &TestClickHouse{container: ctr, Conn: chConn, URL: connStr}
-
 	t.Cleanup(func() {
-		_ = chConn.Close()
-		if err := ctr.Terminate(context.Background()); err != nil {
-			fmt.Printf("testutil: terminate clickhouse container: %v\n", err)
+		_ = conn.Close()
+		// Background, not t.Context: the test's context is already cancelled once
+		// cleanups run, so the drop would never be sent.
+		//
+		// sync: the databases here are Atomic, which detaches a dropped table at once
+		// but only unlinks its data after database_atomic_delay_before_drop_table_sec
+		// (480s). The database leaves system.databases either way, so nothing looks
+		// wrong — but without sync every test's tables sit in system.dropped_tables
+		// holding their data, and a package's worth of them accumulates in a container
+		// the whole package shares. sync unlinks before returning.
+		if _, err := sc.admin.ExecContext(context.Background(),
+			fmt.Sprintf("drop database if exists %s sync", quoteCH(name))); err != nil {
+			t.Errorf("testutil: drop clickhouse database %s: %v", name, err)
 		}
 	})
 
-	return tc
+	return &TestClickHouse{Conn: conn, URL: dsn}
 }
 
-// SetupBareClickHouse starts a ClickHouse container without running migrations.
-// Use this when testing migration logic directly. Cleanup is registered via t.Cleanup.
-func SetupBareClickHouse(t *testing.T) *TestClickHouse {
-	t.Helper()
+func startClickHouse() (_ *sharedClickHouse, err error) {
+	// Background, not the triggering test's t.Context: this container is shared by
+	// the whole package and outlives whichever test started it.
 	ctx := context.Background()
 
 	ctr, err := tcclickhouse.Run(ctx, testClickHouseImage,
-		tcclickhouse.WithDatabase("pug_test"),
+		tcclickhouse.WithDatabase(chAdminDB),
 		tcclickhouse.WithUsername("default"),
 		tcclickhouse.WithPassword("test"),
 	)
+	// Run hands back a created-but-never-ready container alongside its error when
+	// the readiness probe times out, so every failure path below has to terminate
+	// it. TerminateContainer tolerates a nil container.
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, testcontainers.TerminateContainer(ctr))
+		}
+	}()
 	if err != nil {
-		t.Fatalf("testutil: start clickhouse container: %v", err)
+		return nil, fmt.Errorf("start container: %w", err)
 	}
 
 	connStr, err := ctr.ConnectionString(ctx)
 	if err != nil {
-		_ = ctr.Terminate(ctx)
-		t.Fatalf("testutil: get clickhouse connection string: %v", err)
+		return nil, fmt.Errorf("connection string: %w", err)
 	}
 
-	tc := &TestClickHouse{container: ctr, URL: connStr}
+	base, err := url.Parse(connStr)
+	if err != nil {
+		return nil, fmt.Errorf("parse connection string: %w", err)
+	}
+	connFor := func(db string) string {
+		u := *base
+		u.Path = "/" + db
+		return u.String()
+	}
 
-	t.Cleanup(func() {
-		if err := ctr.Terminate(context.Background()); err != nil {
-			fmt.Printf("testutil: terminate clickhouse container: %v\n", err)
+	admin, err := sql.Open("clickhouse", connFor(chAdminDB))
+	if err != nil {
+		return nil, fmt.Errorf("admin connection: %w", err)
+	}
+
+	teardowns.add(func() error {
+		_ = admin.Close()
+		if err := testcontainers.TerminateContainer(ctr); err != nil {
+			return fmt.Errorf("terminate clickhouse container: %w", err)
 		}
+		return nil
 	})
 
-	return tc
+	return &sharedClickHouse{admin: admin, connFor: connFor}, nil
+}
+
+// quoteCH quotes a ClickHouse identifier. The names it is given are generated,
+// not caller-supplied, so this is hygiene rather than a trust boundary.
+func quoteCH(ident string) string {
+	return "`" + ident + "`"
 }
 
 func migrateClickHouse(ctx context.Context, connStr string) error {

--- a/internal/testutil/clickhouse.go
+++ b/internal/testutil/clickhouse.go
@@ -63,18 +63,14 @@ func SetupClickHouse(t *testing.T) *TestClickHouse {
 		t.Fatalf("testutil: create clickhouse database: %v", err)
 	}
 
-	dsn := sc.connFor(name)
-	if err := migrateClickHouse(ctx, dsn); err != nil {
-		t.Fatalf("testutil: run clickhouse migrations: %v", err)
-	}
-
-	conn, err := chdep.NewReaderPool(ctx, &chdep.Config{URL: dsn})
-	if err != nil {
-		t.Fatalf("testutil: create clickhouse connection: %v", err)
-	}
-
+	// Registered before the migration and connection so a failure in either still
+	// drops the database; otherwise it would linger in the shared container for
+	// the rest of the package. The connection is closed only once set.
+	var conn *chdep.Conn
 	t.Cleanup(func() {
-		_ = conn.Close()
+		if conn != nil {
+			_ = conn.Close()
+		}
 		// Background, not t.Context: the test's context is already cancelled once
 		// cleanups run, so the drop would never be sent.
 		//
@@ -89,6 +85,16 @@ func SetupClickHouse(t *testing.T) *TestClickHouse {
 			t.Errorf("testutil: drop clickhouse database %s: %v", name, err)
 		}
 	})
+
+	dsn := sc.connFor(name)
+	if err := migrateClickHouse(ctx, dsn); err != nil {
+		t.Fatalf("testutil: run clickhouse migrations: %v", err)
+	}
+
+	conn, err := chdep.NewReaderPool(ctx, &chdep.Config{URL: dsn})
+	if err != nil {
+		t.Fatalf("testutil: create clickhouse connection: %v", err)
+	}
 
 	return &TestClickHouse{Conn: conn, URL: dsn}
 }

--- a/internal/testutil/main_wired_test.go
+++ b/internal/testutil/main_wired_test.go
@@ -185,12 +185,23 @@ func assertScanIsLive(t *testing.T, s pkgScan) {
 
 // skipDir keeps the walk out of trees with no hand-written tests to check.
 //
+// It ignores what standard Go tooling ignores — directory names beginning with
+// "." or "_", plus "testdata" and "vendor" — so a deliberately malformed
+// *_test.go kept as a parser fixture can't fail the ParseFile above; node_modules
+// and bin are dropped for the same reason (".git" falls under the "." rule). The
+// walk root is the repo root, which repoRoot builds through filepath.Join and so
+// is already cleaned, so its own name never trips the "." rule.
+//
 // The generated-code case has to compare the path relative to the root:
 // fs.DirEntry.Name reports the final element alone, so matching "internal/gen"
 // against it would silently never fire.
 func skipDir(root, path string, d fs.DirEntry) bool {
-	switch d.Name() {
-	case ".git", "node_modules", "bin":
+	name := d.Name()
+	if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
+		return true
+	}
+	switch name {
+	case "testdata", "vendor", "node_modules", "bin":
 		return true
 	}
 	rel, err := filepath.Rel(root, path)

--- a/internal/testutil/main_wired_test.go
+++ b/internal/testutil/main_wired_test.go
@@ -1,0 +1,245 @@
+package testutil_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// setupHelpers are the testutil entry points that start a container shared by a
+// whole package. The scan below keys off these names, so a rename that missed
+// this list would leave that helper's packages unchecked while the rest kept the
+// scan looking healthy — assertScanIsLive is what makes that loud.
+var setupHelpers = []string{"SetupPostgres", "SetupClickHouse", "SetupNATS", "SetupRedis"}
+
+// pkgScan is what one walk over the repo's test files yields. Every field is
+// keyed by directory, which is also the unit a test binary is built from.
+type pkgScan struct {
+	// helperDirs maps each Setup* helper to the directories that call it.
+	helperDirs map[string][]string
+	// setupDirs holds every directory calling any Setup* helper.
+	setupDirs map[string]bool
+	// declaresMain holds directories declaring a TestMain, wired or not.
+	declaresMain map[string]bool
+	// wiresMain holds directories whose TestMain reaches testutil.Main.
+	wiresMain map[string]bool
+	// parallelFiles maps a directory to the test files in it calling Parallel().
+	parallelFiles map[string][]string
+}
+
+// TestSetupCallersWireMain asserts that every package whose tests call a
+// testutil.Setup* helper hands its run to testutil.Main.
+//
+// The helpers share one container per test binary, so the container's teardown
+// hangs off Main rather than any single test's t.Cleanup. A package that skips it
+// still passes — it just strands its containers, with no failing test to point at.
+// This is that failing test.
+func TestSetupCallersWireMain(t *testing.T) {
+	s := scanTests(t)
+	assertScanIsLive(t, s)
+
+	var missing, unwired []string
+	for dir := range s.setupDirs {
+		switch {
+		case !s.declaresMain[dir]:
+			missing = append(missing, relTo(t, dir))
+		case !s.wiresMain[dir]:
+			unwired = append(unwired, relTo(t, dir))
+		}
+	}
+	slices.Sort(missing)
+	slices.Sort(unwired)
+
+	const remedy = "\n\nhand the run to testutil.Main:\n\n\tfunc TestMain(m *testing.M) { testutil.Main(m) }"
+
+	if len(missing) > 0 {
+		t.Errorf("these packages call testutil.Setup* without declaring TestMain, so their shared containers outlive the run:\n\t%s%s",
+			strings.Join(missing, "\n\t"), remedy)
+	}
+	// Checking for TestMain by name alone would pass the idiomatic
+	// os.Exit(m.Run()) — a TestMain that never tears a container down, and the
+	// likeliest way to arrive at one is to add it for something else first.
+	if len(unwired) > 0 {
+		t.Errorf("these packages declare TestMain but never reach testutil.Main, so their shared containers outlive the run:\n\t%s%s",
+			strings.Join(unwired, "\n\t"), remedy)
+	}
+}
+
+// TestSetupCallersDoNotUseParallel asserts that no package sharing a container
+// runs its tests concurrently.
+//
+// The per-test isolation the helpers provide is not uniform. Postgres and
+// ClickHouse hand out a private database and would survive concurrency; NATS and
+// Redis have nowhere to put one, so SetupNATS rebuilds every stream in the
+// container and SetupRedis recycles 16 logical databases and flushes on entry.
+// Either will wipe a concurrently running test's state from under it.
+//
+// The guard is package-wide rather than per-helper because a package mixes the
+// helpers freely, and because the damage is silent: the victim either fails
+// somewhere unrelated to the cause, or passes having asserted over state that was
+// deleted mid-test.
+func TestSetupCallersDoNotUseParallel(t *testing.T) {
+	s := scanTests(t)
+	assertScanIsLive(t, s)
+
+	var offenders []string
+	for dir := range s.setupDirs {
+		for _, file := range s.parallelFiles[dir] {
+			offenders = append(offenders, relTo(t, file))
+		}
+	}
+	slices.Sort(offenders)
+	offenders = slices.Compact(offenders)
+
+	if len(offenders) > 0 {
+		t.Errorf("these files call Parallel() in a package that shares a container, which lets one test delete another's state mid-run:\n\t%s\n\nrun them sequentially, or give the package a namespace per test that survives concurrency (see SetupPostgres) before parallelising it",
+			strings.Join(offenders, "\n\t"))
+	}
+}
+
+// scanTests parses every _test.go in the repo once and reports what the guards
+// above need to know about each directory.
+func scanTests(t *testing.T) pkgScan {
+	t.Helper()
+
+	root := repoRoot(t)
+	fset := token.NewFileSet()
+	s := pkgScan{
+		helperDirs:    map[string][]string{},
+		setupDirs:     map[string]bool{},
+		declaresMain:  map[string]bool{},
+		wiresMain:     map[string]bool{},
+		parallelFiles: map[string][]string{},
+	}
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipDir(root, path, d) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		f, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+
+		dir := filepath.Dir(path)
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.FuncDecl:
+				if node.Recv == nil && node.Name.Name == "TestMain" {
+					s.declaresMain[dir] = true
+					if callsTestutilMain(node) {
+						s.wiresMain[dir] = true
+					}
+				}
+			case *ast.SelectorExpr:
+				if id, ok := node.X.(*ast.Ident); ok && id.Name == "testutil" && strings.HasPrefix(node.Sel.Name, "Setup") {
+					s.setupDirs[dir] = true
+					s.helperDirs[node.Sel.Name] = append(s.helperDirs[node.Sel.Name], dir)
+				}
+			case *ast.CallExpr:
+				if isParallelCall(node) {
+					s.parallelFiles[dir] = append(s.parallelFiles[dir], path)
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repo: %v", err)
+	}
+
+	return s
+}
+
+// assertScanIsLive guards against the scan quietly matching nothing — a renamed
+// helper, a moved root — which would leave these tests passing forever without
+// checking anything.
+func assertScanIsLive(t *testing.T, s pkgScan) {
+	t.Helper()
+
+	// Per helper, not merely in total: three helpers keeping the total non-zero
+	// would mask a fourth whose packages had stopped being checked.
+	for _, helper := range setupHelpers {
+		if len(s.helperDirs[helper]) == 0 {
+			t.Fatalf("scan found no caller of testutil.%s; it has drifted and no longer checks that helper's packages (update setupHelpers if it was renamed or retired)", helper)
+		}
+	}
+}
+
+// skipDir keeps the walk out of trees with no hand-written tests to check.
+//
+// The generated-code case has to compare the path relative to the root:
+// fs.DirEntry.Name reports the final element alone, so matching "internal/gen"
+// against it would silently never fire.
+func skipDir(root, path string, d fs.DirEntry) bool {
+	switch d.Name() {
+	case ".git", "node_modules", "bin":
+		return true
+	}
+	rel, err := filepath.Rel(root, path)
+	return err == nil && rel == filepath.Join("internal", "gen")
+}
+
+// callsTestutilMain reports whether fn's body hands the run to testutil.Main.
+func callsTestutilMain(fn *ast.FuncDecl) bool {
+	var found bool
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if id, ok := sel.X.(*ast.Ident); ok && id.Name == "testutil" && sel.Sel.Name == "Main" {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// isParallelCall reports whether n is a no-argument Parallel() call. The receiver
+// is left unmatched: subtests rename their *testing.T freely, and nothing else in
+// a test file offers that signature.
+func isParallelCall(n *ast.CallExpr) bool {
+	sel, ok := n.Fun.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "Parallel" && len(n.Args) == 0
+}
+
+func relTo(t *testing.T, path string) string {
+	t.Helper()
+	rel, err := filepath.Rel(repoRoot(t), path)
+	if err != nil {
+		return path
+	}
+	return rel
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("unable to determine source file path")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", "..")
+}

--- a/internal/testutil/nats.go
+++ b/internal/testutil/nats.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -26,55 +27,80 @@ const (
 	testStreamMaxAge   = 24 * time.Hour
 )
 
-// TestNATS holds a NATS testcontainer for testing.
+// TestNATS holds the connection URL for the package's NATS container.
 type TestNATS struct {
-	container *nats.NATSContainer
-	URL       string
+	URL string
 }
 
-// SetupNATS starts a NATS container with JetStream enabled.
-// It registers a cleanup function on the test to terminate the container.
-// It also runs NATS migrations to create streams and consumers.
+// sharedNATS is the single container backing every test in the package.
+type sharedNATS struct {
+	url string
+}
+
+var natsContainer = &lazyContainer[sharedNATS]{kind: "nats", start: startNATS}
+
+// SetupNATS returns a URL onto the package's NATS container with the configured
+// streams and consumers freshly created. The container is started once per test
+// binary and torn down by Main.
+//
+// Unlike Postgres and ClickHouse, JetStream has no per-test namespace to hand
+// out, so isolation comes from rebuilding the streams on every call: dropping a
+// stream drops its messages and its consumers' ack state along with it, which
+// is the state a test could otherwise inherit from the one before it.
 func SetupNATS(t *testing.T) *TestNATS {
 	t.Helper()
+	// Scoped to the test — see the note in SetupPostgres for why the shared
+	// container uses context.Background instead.
+	ctx := t.Context()
 
+	tn := &TestNATS{URL: natsContainer.get(t).url}
+
+	if err := tn.resetJetStream(ctx); err != nil {
+		t.Fatalf("testutil: reset jetstream: %v", err)
+	}
+	if err := tn.runMigrations(ctx); err != nil {
+		t.Fatalf("testutil: run nats migrations: %v", err)
+	}
+
+	return tn
+}
+
+func startNATS() (_ *sharedNATS, err error) {
+	// Background, not the triggering test's t.Context: this container is shared by
+	// the whole package and outlives whichever test started it.
 	ctx := context.Background()
 
 	ctr, err := nats.Run(ctx, testNATSImage)
+	// Run hands back a created-but-never-ready container alongside its error when
+	// the readiness probe times out, so every failure path below has to terminate
+	// it. TerminateContainer tolerates a nil container.
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, testcontainers.TerminateContainer(ctr))
+		}
+	}()
 	if err != nil {
-		t.Fatalf("testutil: start nats container: %v", err)
+		return nil, fmt.Errorf("start container: %w", err)
 	}
 
 	url, err := ctr.ConnectionString(ctx)
 	if err != nil {
-		_ = testcontainers.TerminateContainer(ctr)
-		t.Fatalf("testutil: get nats connection string: %v", err)
+		return nil, fmt.Errorf("connection string: %w", err)
 	}
 
 	// Wait for NATS to be fully ready by attempting a connection with retries.
-	if err := waitForNATS(url, 30*time.Second); err != nil {
-		_ = testcontainers.TerminateContainer(ctr)
-		t.Fatalf("testutil: wait for nats ready: %v", err)
+	if err = waitForNATS(url, 30*time.Second); err != nil {
+		return nil, fmt.Errorf("wait for nats ready: %w", err)
 	}
 
-	tn := &TestNATS{
-		container: ctr,
-		URL:       url,
-	}
-
-	// Run NATS migrations (create streams and consumers).
-	if err := tn.runMigrations(ctx, t); err != nil {
-		_ = testcontainers.TerminateContainer(ctr)
-		t.Fatalf("testutil: run nats migrations: %v", err)
-	}
-
-	t.Cleanup(func() {
+	teardowns.add(func() error {
 		if err := testcontainers.TerminateContainer(ctr); err != nil {
-			fmt.Printf("testutil: terminate nats container: %v\n", err)
+			return fmt.Errorf("terminate nats container: %w", err)
 		}
+		return nil
 	})
 
-	return tn
+	return &sharedNATS{url: url}, nil
 }
 
 func waitForNATS(url string, timeout time.Duration) error {
@@ -98,7 +124,40 @@ func waitForNATS(url string, timeout time.Duration) error {
 	}
 }
 
-func (tn *TestNATS) runMigrations(ctx context.Context, _ *testing.T) error {
+// resetJetStream drops every stream left behind by an earlier test in this
+// package, along with the consumers that hang off them. runMigrations recreates
+// both.
+func (tn *TestNATS) resetJetStream(ctx context.Context) error {
+	nc, err := natsgo.Connect(tn.URL)
+	if err != nil {
+		return fmt.Errorf("connect to nats: %w", err)
+	}
+	defer nc.Close()
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		return fmt.Errorf("create jetstream: %w", err)
+	}
+
+	lister := js.StreamNames(ctx)
+	var names []string
+	for name := range lister.Name() {
+		names = append(names, name)
+	}
+	if err := lister.Err(); err != nil {
+		return fmt.Errorf("list streams: %w", err)
+	}
+
+	for _, name := range names {
+		if err := js.DeleteStream(ctx, name); err != nil {
+			return fmt.Errorf("delete stream %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+func (tn *TestNATS) runMigrations(ctx context.Context) error {
 	nc, err := natsgo.Connect(tn.URL)
 	if err != nil {
 		return fmt.Errorf("connect to nats: %w", err)

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -137,11 +137,15 @@ func SetupPostgres(t *testing.T) *TestPostgres {
 		}
 		// Background, not t.Context: the test's context is already cancelled by
 		// the time cleanups run, so the drop would never be sent and the database
-		// would linger in the shared container for the rest of the package.
+		// would linger in the shared container for the rest of the package. The
+		// timeout backstops a wedged connection hanging the drop — and with it the
+		// rest of the sequential package — until go test -timeout (cleanupDropTimeout).
 		//
 		// force: pgxpool releases connections asynchronously, and a backend that
 		// outlives the pool holds the database open against a plain drop.
-		if _, err := sp.admin.Exec(context.Background(),
+		dropCtx, cancel := context.WithTimeout(context.Background(), cleanupDropTimeout)
+		defer cancel()
+		if _, err := sp.admin.Exec(dropCtx,
 			fmt.Sprintf("drop database if exists %s with (force)", quoted)); err != nil {
 			t.Errorf("testutil: drop test database %s: %v", name, err)
 		}

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -3,75 +3,249 @@ package testutil
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"testing"
 
+	"github.com/testcontainers/testcontainers-go"
+
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/pressly/goose/v3"
+	"github.com/rs/xid"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 )
 
 const testPostgresImage = "postgres@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88" // PostgreSQL 18.4-alpine
 
-// TestPostgres holds the container and connection pools for a test database.
+const (
+	// pgTemplateDB holds the migrated schema every test database is cloned from.
+	// Migrations run against it once per test binary, after which nothing may
+	// connect: CREATE DATABASE ... TEMPLATE is refused while any session is
+	// attached to the source. sealTemplate enforces that.
+	pgTemplateDB = "pug_template"
+
+	// pgAdminDB is the database the CREATE/DROP DATABASE statements are issued
+	// from. It is neither the template nor a test database, so those statements
+	// never run from a connection to their own target.
+	pgAdminDB = "postgres"
+
+	// pgPoolMaxConns caps each pool's backends. pgxpool otherwise defaults
+	// MaxConns to max(4, NumCPU), so on a many-core machine a test's two pools
+	// alone could approach the server's max_connections of 100 — which every test
+	// in the package now shares rather than getting a server of its own.
+	//
+	// It is a ceiling, not a reservation: MinConns is 0, so a pool holds only what
+	// it uses. 8 is the suite's widest fan-out — internal/core/auth's refresh and
+	// magic-link races each run 8 goroutines through one pool — so all of them
+	// reach the database together instead of queueing in Acquire for a connection,
+	// which is the overlap those tests exist to create. Raise it alongside any
+	// test that fans out wider.
+	//
+	// The ceiling that matters is one test's two pools plus the admin pool: 24
+	// backends against 100, and a binary's tests run sequentially
+	// (TestSetupCallersDoNotUseParallel), so no other test is holding any.
+	pgPoolMaxConns = 8
+)
+
+// TestPostgres holds the connection pools for one test's private database.
 type TestPostgres struct {
-	container *tcpostgres.PostgresContainer
-	PgRO      *pgxpool.Pool
-	PgW       *pgxpool.Pool
+	PgRO *pgxpool.Pool
+	PgW  *pgxpool.Pool
 }
 
-// SetupPostgres starts a PostgreSQL container, runs all goose migrations,
-// and returns connection pools. Cleanup is registered via t.Cleanup.
+// sharedPostgres is the single container backing every test in the package.
+type sharedPostgres struct {
+	admin *pgxpool.Pool
+	base  *url.URL
+}
+
+// plainDSN builds a connection string for db carrying no pgxpool-only
+// parameters, for a plain pgx connection such as migrate's sql.Open.
+//
+// The two DSN builders are separate functions rather than one with a flag
+// because each is wrong in a different way at the other's call site, and only
+// one of the two mistakes is visible. See poolDSN.
+func plainDSN(base *url.URL, db string) string {
+	u := *base
+	u.Path = "/" + db
+	return u.String()
+}
+
+// poolDSN builds a connection string for db carrying the pgPoolMaxConns cap, for
+// pgxpool.New.
+//
+// Handing it to a plain pgx connection announces itself: pgx forwards a key it
+// does not recognize to the server as a runtime parameter, so pool_max_conns
+// fails the connection outright (SQLSTATE 42704) rather than being ignored. The
+// reverse — a plainDSN reaching pgxpool.New — is the quiet one: the pool builds
+// fine and falls back to its max(4, NumCPU) default, which is the cap's entire
+// reason for existing, and nothing says so.
+func poolDSN(base *url.URL, db string) string {
+	u := *base
+	u.Path = "/" + db
+	q := u.Query()
+	q.Set("pool_max_conns", strconv.Itoa(pgPoolMaxConns))
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+var pgContainer = &lazyContainer[sharedPostgres]{kind: "postgres", start: startPostgres}
+
+// SetupPostgres returns read and write pools onto a freshly migrated database
+// private to this test. Cleanup is registered via t.Cleanup.
+//
+// The container is started once per test binary and shared by the package's
+// tests; each test's isolation comes from its own database cloned off a
+// pre-migrated template, which costs milliseconds against the seconds a
+// container start plus a migration run costs. Packages must wire up Main to
+// tear the container down.
 func SetupPostgres(t *testing.T) *TestPostgres {
 	t.Helper()
+	// Scoped to the test: t.Context is cancelled just before this test's cleanups
+	// run, so a test that times out stops waiting on its own database too. The
+	// shared container and the cleanup below deliberately do not use it — see
+	// startPostgres and the t.Cleanup body.
+	ctx := t.Context()
+
+	sp := pgContainer.get(t)
+
+	name := "test_" + xid.New().String()
+	quoted := pgx.Identifier{name}.Sanitize()
+
+	if _, err := sp.admin.Exec(ctx, fmt.Sprintf("create database %s template %s",
+		quoted, pgx.Identifier{pgTemplateDB}.Sanitize())); err != nil {
+		t.Fatalf("testutil: create test database: %v", err)
+	}
+
+	dsn := poolDSN(sp.base, name)
+
+	pgRO, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("testutil: create read pool: %v", err)
+	}
+
+	pgW, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		pgRO.Close()
+		t.Fatalf("testutil: create write pool: %v", err)
+	}
+
+	t.Cleanup(func() {
+		pgRO.Close()
+		pgW.Close()
+		// Background, not t.Context: the test's context is already cancelled by
+		// the time cleanups run, so the drop would never be sent and the database
+		// would linger in the shared container for the rest of the package.
+		//
+		// force: pgxpool releases connections asynchronously, and a backend that
+		// outlives the pool holds the database open against a plain drop.
+		if _, err := sp.admin.Exec(context.Background(),
+			fmt.Sprintf("drop database if exists %s with (force)", quoted)); err != nil {
+			t.Errorf("testutil: drop test database %s: %v", name, err)
+		}
+	})
+
+	return &TestPostgres{PgRO: pgRO, PgW: pgW}
+}
+
+func startPostgres() (_ *sharedPostgres, err error) {
+	// Background, not the triggering test's t.Context: this container is shared by
+	// the whole package and outlives whichever test happened to start it, so
+	// binding it to that test's context would tear it down under the next one.
 	ctx := context.Background()
 
 	ctr, err := tcpostgres.Run(ctx, testPostgresImage,
-		tcpostgres.WithDatabase("pug_test"),
+		tcpostgres.WithDatabase(pgTemplateDB),
 		tcpostgres.WithUsername("postgres"),
 		tcpostgres.WithPassword("postgres"),
 		tcpostgres.WithSQLDriver("pgx"),
 		tcpostgres.BasicWaitStrategies(),
 	)
-	if err != nil {
-		t.Fatalf("testutil: start postgres container: %v", err)
-	}
-
-	connStr := ctr.MustConnectionString(ctx, "sslmode=disable")
-
-	if err := migrate(ctx, connStr); err != nil {
-		_ = ctr.Terminate(ctx)
-		t.Fatalf("testutil: run migrations: %v", err)
-	}
-
-	pgRO, err := pgxpool.New(ctx, connStr)
-	if err != nil {
-		_ = ctr.Terminate(ctx)
-		t.Fatalf("testutil: create read pool: %v", err)
-	}
-
-	pgW, err := pgxpool.New(ctx, connStr)
-	if err != nil {
-		pgRO.Close()
-		_ = ctr.Terminate(ctx)
-		t.Fatalf("testutil: create write pool: %v", err)
-	}
-
-	tp := &TestPostgres{container: ctr, PgRO: pgRO, PgW: pgW}
-
-	t.Cleanup(func() {
-		pgRO.Close()
-		pgW.Close()
-		if err := ctr.Terminate(context.Background()); err != nil {
-			fmt.Printf("testutil: terminate postgres container: %v\n", err)
+	// Run hands back a created-but-never-ready container alongside its error when
+	// the readiness probe times out, so every failure path below has to terminate
+	// it. TerminateContainer tolerates a nil container.
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, testcontainers.TerminateContainer(ctr))
 		}
+	}()
+	if err != nil {
+		return nil, fmt.Errorf("start container: %w", err)
+	}
+
+	// ConnectionString, not MustConnectionString: the Must variant panics, and a
+	// panic here would carry err past the defer above still nil, so the container
+	// it just decided it could not describe would never be terminated.
+	connStr, err := ctr.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		return nil, fmt.Errorf("connection string: %w", err)
+	}
+
+	base, err := url.Parse(connStr)
+	if err != nil {
+		return nil, fmt.Errorf("parse connection string: %w", err)
+	}
+	// Migrations run against the template exactly once; every test database is a
+	// copy of the result. This is also the only connection the template ever takes
+	// — see sealTemplate, which closes it to any other.
+	if err = migrate(ctx, plainDSN(base, pgTemplateDB)); err != nil {
+		return nil, fmt.Errorf("migrate template: %w", err)
+	}
+
+	admin, err := pgxpool.New(ctx, poolDSN(base, pgAdminDB))
+	if err != nil {
+		return nil, fmt.Errorf("admin pool: %w", err)
+	}
+
+	if err = sealTemplate(ctx, admin); err != nil {
+		admin.Close()
+		return nil, err
+	}
+
+	teardowns.add(func() error {
+		admin.Close()
+		if err := testcontainers.TerminateContainer(ctr); err != nil {
+			return fmt.Errorf("terminate postgres container: %w", err)
+		}
+		return nil
 	})
 
-	return tp
+	return &sharedPostgres{admin: admin, base: base}, nil
+}
+
+// sealTemplate locks the template down once it is migrated. CREATE DATABASE ...
+// TEMPLATE fails outright while any session is attached to the source (SQLSTATE
+// 55006), and migrate above is the only thing that ever connects to it — the
+// readiness probe waits on a log line and a listening port, never opening a
+// session.
+//
+// database/sql closes its connections inline, so in practice the template is
+// already idle by the time this runs. Barring new connections turns that into a
+// guarantee, and turns a future stray connection to the template into a loud
+// error at the point of the mistake rather than a clone that fails
+// intermittently. Evicting whatever is still attached covers the remainder: the
+// two-argument pg_terminate_backend waits for the backend to exit, where the
+// one-argument form returns once the signal is merely sent and would leave the
+// first clone racing a dying session.
+func sealTemplate(ctx context.Context, admin *pgxpool.Pool) error {
+	quoted := pgx.Identifier{pgTemplateDB}.Sanitize()
+
+	if _, err := admin.Exec(ctx, fmt.Sprintf("alter database %s with allow_connections false", quoted)); err != nil {
+		return fmt.Errorf("bar connections to template: %w", err)
+	}
+	if _, err := admin.Exec(ctx,
+		"select pg_terminate_backend(pid, 5000) from pg_stat_activity where datname = $1 and pid <> pg_backend_pid()",
+		pgTemplateDB); err != nil {
+		return fmt.Errorf("evict template sessions: %w", err)
+	}
+	return nil
 }
 
 func migrate(ctx context.Context, connStr string) error {

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -124,22 +124,17 @@ func SetupPostgres(t *testing.T) *TestPostgres {
 		t.Fatalf("testutil: create test database: %v", err)
 	}
 
-	dsn := poolDSN(sp.base, name)
-
-	pgRO, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		t.Fatalf("testutil: create read pool: %v", err)
-	}
-
-	pgW, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		pgRO.Close()
-		t.Fatalf("testutil: create write pool: %v", err)
-	}
-
+	// Registered before the pools are built so a failure between here and the
+	// return still drops the database; otherwise it would linger in the shared
+	// container for the rest of the package. Each pool is closed only once set.
+	var pgRO, pgW *pgxpool.Pool
 	t.Cleanup(func() {
-		pgRO.Close()
-		pgW.Close()
+		if pgRO != nil {
+			pgRO.Close()
+		}
+		if pgW != nil {
+			pgW.Close()
+		}
 		// Background, not t.Context: the test's context is already cancelled by
 		// the time cleanups run, so the drop would never be sent and the database
 		// would linger in the shared container for the rest of the package.
@@ -151,6 +146,19 @@ func SetupPostgres(t *testing.T) *TestPostgres {
 			t.Errorf("testutil: drop test database %s: %v", name, err)
 		}
 	})
+
+	dsn := poolDSN(sp.base, name)
+
+	var err error
+	pgRO, err = pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("testutil: create read pool: %v", err)
+	}
+
+	pgW, err = pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("testutil: create write pool: %v", err)
+	}
 
 	return &TestPostgres{PgRO: pgRO, PgW: pgW}
 }

--- a/internal/testutil/postgres_test.go
+++ b/internal/testutil/postgres_test.go
@@ -1,0 +1,66 @@
+package testutil
+
+import (
+	"net/url"
+	"strconv"
+	"testing"
+)
+
+const testBaseDSN = "postgres://postgres:postgres@localhost:32768/pug_template?sslmode=disable"
+
+// TestPoolDSNCarriesConnectionCap pins the quiet half of the plainDSN/poolDSN
+// split. A pool built from a DSN that has lost pool_max_conns works perfectly and
+// silently takes pgxpool's max(4, NumCPU) default, so no other test in the suite
+// would notice the cap going missing.
+//
+// The loud half needs no test: a pool_max_conns reaching migrate's plain pgx
+// connection is forwarded to the server as a runtime parameter and fails every
+// Postgres test in the repo outright.
+func TestPoolDSNCarriesConnectionCap(t *testing.T) {
+	got := mustParse(t, poolDSN(mustParse(t, testBaseDSN), "test_db"))
+
+	if want := strconv.Itoa(pgPoolMaxConns); got.Query().Get("pool_max_conns") != want {
+		t.Errorf("pool_max_conns = %q, want %q", got.Query().Get("pool_max_conns"), want)
+	}
+	if got.Path != "/test_db" {
+		t.Errorf("path = %q, want %q", got.Path, "/test_db")
+	}
+	if got.Query().Get("sslmode") != "disable" {
+		t.Error("poolDSN dropped the base DSN's own parameters")
+	}
+}
+
+func TestPlainDSNOmitsPoolParams(t *testing.T) {
+	got := mustParse(t, plainDSN(mustParse(t, testBaseDSN), "test_db"))
+
+	if got.Query().Has("pool_max_conns") {
+		t.Error("plainDSN carries pool_max_conns, which pgx forwards to the server as a runtime parameter, failing the connection")
+	}
+	if got.Path != "/test_db" {
+		t.Errorf("path = %q, want %q", got.Path, "/test_db")
+	}
+}
+
+// TestDSNBuildersDoNotMutateBase guards the copy in each builder. sharedPostgres
+// hands the same *url.URL to every test in the package, so a builder that wrote
+// through the pointer instead of its own copy would rewrite the target database
+// for everything that came after it.
+func TestDSNBuildersDoNotMutateBase(t *testing.T) {
+	base := mustParse(t, testBaseDSN)
+
+	plainDSN(base, "one")
+	poolDSN(base, "two")
+
+	if got := base.String(); got != testBaseDSN {
+		t.Errorf("base = %q, want it untouched at %q", got, testBaseDSN)
+	}
+}
+
+func mustParse(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return u
+}

--- a/internal/testutil/redis.go
+++ b/internal/testutil/redis.go
@@ -2,8 +2,12 @@ package testutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
+
+	"github.com/testcontainers/testcontainers-go"
 
 	goredis "github.com/redis/go-redis/v9"
 	"github.com/testcontainers/testcontainers-go/modules/redis"
@@ -14,63 +18,103 @@ import (
 // Redis stands in for it in tests via the testcontainers redis module.
 const testRedisImage = "redis@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2" // 8.6.3-alpine
 
-// TestRedis holds a Redis testcontainer for testing.
+// redisDBCount is Redis' default number of logical databases. Tests are handed
+// one each, so they share a container without sharing keyspace.
+const redisDBCount = 16
+
+// TestRedis holds a client onto one test's private Redis database.
 type TestRedis struct {
-	container *redis.RedisContainer
-	URL       string
-	Client    *goredis.Client
+	URL    string
+	Client *goredis.Client
 }
 
-// SetupRedis starts a Redis container and returns a connected client.
-// Cleanup is registered via t.Cleanup.
+// sharedRedis is the single container backing every test in the package.
+type sharedRedis struct {
+	addr string
+}
+
+var redisContainer = &lazyContainer[sharedRedis]{kind: "redis", start: startRedis}
+
+// redisDBSeq hands out logical database indexes. It wraps at redisDBCount, so
+// an index can be reused by a later test in the same package — hence the flush
+// on the way in as well as the way out.
+var redisDBSeq atomic.Uint64
+
+// SetupRedis starts (or reuses) the package's Redis container and returns a
+// client scoped to a logical database private to this test. Cleanup is
+// registered via t.Cleanup; the container is torn down by Main.
 func SetupRedis(t *testing.T) *TestRedis {
 	t.Helper()
-	ctx := context.Background()
+	// Scoped to the test — see the note in SetupPostgres for why the shared
+	// container and the cleanup below use context.Background instead.
+	ctx := t.Context()
 
-	ctr, err := redis.Run(ctx, testRedisImage)
-	if err != nil {
-		t.Fatalf("testutil: start redis container: %v", err)
-	}
-
-	host, err := ctr.Host(ctx)
-	if err != nil {
-		_ = ctr.Terminate(ctx)
-		t.Fatalf("testutil: get redis host: %v", err)
-	}
-
-	port, err := ctr.MappedPort(ctx, "6379")
-	if err != nil {
-		_ = ctr.Terminate(ctx)
-		t.Fatalf("testutil: get redis port: %v", err)
-	}
-
-	url := fmt.Sprintf("redis://%s:%s", host, port.Port())
+	addr := redisContainer.get(t).addr
+	db := int(redisDBSeq.Add(1)-1) % redisDBCount
+	url := fmt.Sprintf("redis://%s/%d", addr, db)
 
 	opts, err := goredis.ParseURL(url)
 	if err != nil {
-		_ = ctr.Terminate(ctx)
 		t.Fatalf("testutil: parse redis URL: %v", err)
 	}
 
 	client := goredis.NewClient(opts)
 	if err := client.Ping(ctx).Err(); err != nil {
 		_ = client.Close()
-		_ = ctr.Terminate(ctx)
 		t.Fatalf("testutil: ping redis: %v", err)
 	}
-
-	tr := &TestRedis{
-		container: ctr,
-		URL:       url,
-		Client:    client,
+	if err := client.FlushDB(ctx).Err(); err != nil {
+		_ = client.Close()
+		t.Fatalf("testutil: flush redis db %d: %v", db, err)
 	}
 
 	t.Cleanup(func() {
-		_ = client.Close()
-		if err := ctr.Terminate(ctx); err != nil {
-			fmt.Printf("testutil: terminate redis container: %v\n", err)
+		// Background, not t.Context: the test's context is already cancelled once
+		// cleanups run, so the flush would never be sent and this index would hand
+		// stale keys to whichever later test recycles it.
+		if err := client.FlushDB(context.Background()).Err(); err != nil {
+			t.Errorf("testutil: flush redis db %d: %v", db, err)
 		}
+		_ = client.Close()
 	})
 
-	return tr
+	return &TestRedis{URL: url, Client: client}
+}
+
+func startRedis() (_ *sharedRedis, err error) {
+	// Background, not the triggering test's t.Context: this container is shared by
+	// the whole package and outlives whichever test started it.
+	ctx := context.Background()
+
+	ctr, err := redis.Run(ctx, testRedisImage)
+	// Run hands back a created-but-never-ready container alongside its error when
+	// the readiness probe times out, so every failure path below has to terminate
+	// it. TerminateContainer tolerates a nil container.
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, testcontainers.TerminateContainer(ctr))
+		}
+	}()
+	if err != nil {
+		return nil, fmt.Errorf("start container: %w", err)
+	}
+
+	host, err := ctr.Host(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("container host: %w", err)
+	}
+
+	port, err := ctr.MappedPort(ctx, "6379")
+	if err != nil {
+		return nil, fmt.Errorf("container port: %w", err)
+	}
+
+	teardowns.add(func() error {
+		if err := testcontainers.TerminateContainer(ctr); err != nil {
+			return fmt.Errorf("terminate redis container: %w", err)
+		}
+		return nil
+	})
+
+	return &sharedRedis{addr: fmt.Sprintf("%s:%s", host, port.Port())}, nil
 }

--- a/internal/testutil/redis.go
+++ b/internal/testutil/redis.go
@@ -71,8 +71,12 @@ func SetupRedis(t *testing.T) *TestRedis {
 	t.Cleanup(func() {
 		// Background, not t.Context: the test's context is already cancelled once
 		// cleanups run, so the flush would never be sent and this index would hand
-		// stale keys to whichever later test recycles it.
-		if err := client.FlushDB(context.Background()).Err(); err != nil {
+		// stale keys to whichever later test recycles it. The timeout backstops a
+		// wedged connection hanging the flush — and with it the rest of the
+		// sequential package — until go test -timeout (cleanupDropTimeout).
+		dropCtx, cancel := context.WithTimeout(context.Background(), cleanupDropTimeout)
+		defer cancel()
+		if err := client.FlushDB(dropCtx).Err(); err != nil {
 			t.Errorf("testutil: flush redis db %d: %v", db, err)
 		}
 		_ = client.Close()

--- a/internal/testutil/shared.go
+++ b/internal/testutil/shared.go
@@ -122,16 +122,22 @@ func (r *teardownRegistry) add(fn func() error) {
 //
 // The teardowns run off the lock: each one stops a container, and holding a
 // non-reentrant mutex across that would deadlock a teardown that registered
-// another.
+// another. Re-draining until the registry is empty means such a late
+// registration runs too, rather than being stranded when Main exits.
 func (r *teardownRegistry) run() error {
-	r.mu.Lock()
-	fns := r.fns
-	r.fns = nil
-	r.mu.Unlock()
-
 	var errs []error
-	for i := len(fns) - 1; i >= 0; i-- {
-		errs = append(errs, runTeardown(fns[i]))
+	for {
+		r.mu.Lock()
+		fns := r.fns
+		r.fns = nil
+		r.mu.Unlock()
+
+		if len(fns) == 0 {
+			break
+		}
+		for i := len(fns) - 1; i >= 0; i-- {
+			errs = append(errs, runTeardown(fns[i]))
+		}
 	}
 	return errors.Join(errs...)
 }

--- a/internal/testutil/shared.go
+++ b/internal/testutil/shared.go
@@ -1,0 +1,150 @@
+package testutil
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+)
+
+// Main runs a package's tests and then tears down the containers they shared.
+//
+// Every package whose tests call a Setup* helper must wire this up:
+//
+//	func TestMain(m *testing.M) { testutil.Main(m) }
+//
+// The Setup* helpers start one container per test binary rather than one per
+// test, so a container has no owning test to hang a t.Cleanup on and would
+// otherwise outlive the run. TestSetupCallersWireMain enforces the wiring.
+//
+// The teardown below only covers a normal finish. A panicking test, an expired
+// -timeout or a Ctrl-C all kill the process without m.Run ever returning, and a
+// panic on a test's goroutine will not run a defer on this one, so there is no
+// arrangement here that would cover them. forceRyuk is what covers them.
+func Main(m *testing.M) {
+	forceRyuk()
+
+	code := m.Run()
+
+	if err := teardowns.run(); err != nil {
+		fmt.Fprintf(os.Stderr, "testutil: shutdown: %v\n", err)
+		if code == 0 {
+			code = 1
+		}
+	}
+
+	os.Exit(code)
+}
+
+// forceRyuk turns testcontainers' reaper on for this test binary, overriding a
+// ~/.testcontainers.properties that disables it.
+//
+// Ryuk is a container the test process holds a TCP connection to; it kills
+// everything this session labelled once that connection drops. That makes it the
+// only thing that reaps a package's containers when the process dies without
+// reaching shutdown. Back when a container belonged to a single test, leaking one
+// was survivable and disabling Ryuk cost little; one container per binary shared
+// by every test in it is not, hence overriding a preference rather than reading
+// it.
+//
+// The environment beats the properties file, and the config is read once on first
+// use, so setting it before m.Run is what makes it take. An explicit environment
+// opt-out still wins: Ryuk cannot drive every Docker setup, and a run that cannot
+// start it at all is worse than one that leaks on an abnormal exit.
+func forceRyuk() {
+	if _, explicit := os.LookupEnv("TESTCONTAINERS_RYUK_DISABLED"); explicit {
+		return
+	}
+	if err := os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "false"); err != nil {
+		fmt.Fprintf(os.Stderr, "testutil: enable ryuk: %v\n", err)
+	}
+}
+
+// lazyContainer holds a container started on first use and shared by the rest
+// of the package's tests.
+type lazyContainer[T any] struct {
+	kind  string
+	start func() (*T, error)
+
+	mu  sync.Mutex
+	val *T
+}
+
+// get returns the shared container, starting it if this is the first call.
+//
+// A failed start is deliberately not memoized. Container starts time out when
+// the Docker daemon is saturated — which is exactly when a whole-suite run is
+// underway — and that is transient: the next test may well get its container.
+// Caching the error would turn one unlucky start into a failure for every
+// remaining test in the package, each reported against a stale message that
+// points at the daemon rather than at the test that actually tripped.
+func (l *lazyContainer[T]) get(t *testing.T) *T {
+	t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.val != nil {
+		return l.val
+	}
+	val, err := l.start()
+	if err != nil {
+		t.Fatalf("testutil: start shared %s: %v", l.kind, err)
+	}
+	l.val = val
+	return l.val
+}
+
+// teardownRegistry collects what a package's shared containers need done when its
+// tests finish. The zero value is ready to use.
+type teardownRegistry struct {
+	mu  sync.Mutex
+	fns []func() error
+}
+
+// teardowns is the registry Main drains. It is package state because Go's testing
+// framework offers nowhere else to put it: TestMain cannot hand a value to the
+// tests that register against it, so the one process-wide instance is the only
+// thing both ends can reach. The type keeps that reachability from also meaning
+// the mutex and the slice are separately addressable — every caller goes through
+// a method that holds the right lock.
+var teardowns teardownRegistry
+
+// add records a teardown to run once the package's tests finish.
+func (r *teardownRegistry) add(fn func() error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.fns = append(r.fns, fn)
+}
+
+// run executes every teardown, most recently registered first, and reports what
+// failed. It drains the registry, so a second call is a no-op.
+//
+// The teardowns run off the lock: each one stops a container, and holding a
+// non-reentrant mutex across that would deadlock a teardown that registered
+// another.
+func (r *teardownRegistry) run() error {
+	r.mu.Lock()
+	fns := r.fns
+	r.fns = nil
+	r.mu.Unlock()
+
+	var errs []error
+	for i := len(fns) - 1; i >= 0; i-- {
+		errs = append(errs, runTeardown(fns[i]))
+	}
+	return errors.Join(errs...)
+}
+
+// runTeardown contains a panicking teardown, which would otherwise strand every
+// container still queued behind it and escape Main before it could exit with the
+// suite's own status — reporting a green run as a crash, under a stack through
+// teardown plumbing.
+func runTeardown(fn func() error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("teardown panicked: %v", r)
+		}
+	}()
+	return fn()
+}

--- a/internal/testutil/shared.go
+++ b/internal/testutil/shared.go
@@ -6,7 +6,18 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 )
+
+// cleanupDropTimeout bounds the per-test cleanup that drops a database or flushes
+// a Redis index once a test finishes. Those run on context.Background (t.Context
+// is already cancelled by cleanup time), which without a deadline would let a
+// wedged connection block the drop — and with it the rest of the sequentially run
+// package — until go test -timeout fired with a generic goroutine dump. This is
+// the backstop against that hang: deliberately far longer than any real drop (a
+// ClickHouse sync drop under a saturated daemon must have room to finish, or it
+// fails and leaves its data behind) and far shorter than the suite timeout.
+const cleanupDropTimeout = 30 * time.Second
 
 // Main runs a package's tests and then tears down the containers they shared.
 //

--- a/internal/testutil/shared_test.go
+++ b/internal/testutil/shared_test.go
@@ -1,0 +1,82 @@
+package testutil
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+const ryukDisabledEnv = "TESTCONTAINERS_RYUK_DISABLED"
+
+// TestForceRyukEnablesReaperByDefault pins the override that Main relies on to
+// reap a package's containers when a panic or an expired -timeout kills the
+// process before shutdown can run.
+func TestForceRyukEnablesReaperByDefault(t *testing.T) {
+	// t.Setenv registers the restore; Unsetenv then leaves the variable genuinely
+	// absent, which is the state forceRyuk keys off.
+	t.Setenv(ryukDisabledEnv, "")
+	if err := os.Unsetenv(ryukDisabledEnv); err != nil {
+		t.Fatalf("unset %s: %v", ryukDisabledEnv, err)
+	}
+
+	forceRyuk()
+
+	if got := os.Getenv(ryukDisabledEnv); got != "false" {
+		t.Errorf("%s = %q, want %q so testcontainers starts the reaper", ryukDisabledEnv, got, "false")
+	}
+}
+
+// TestForceRyukRespectsExplicitOptOut pins the escape hatch. Ryuk cannot drive
+// every Docker setup, and a run that cannot start it at all is worse than one
+// that leaks on an abnormal exit — so an explicit opt-out has to survive.
+func TestForceRyukRespectsExplicitOptOut(t *testing.T) {
+	t.Setenv(ryukDisabledEnv, "true")
+
+	forceRyuk()
+
+	if got := os.Getenv(ryukDisabledEnv); got != "true" {
+		t.Errorf("%s = %q, want the caller's %q preserved", ryukDisabledEnv, got, "true")
+	}
+}
+
+// TestTeardownRegistryContainsPanickingTeardown covers the two ways one bad
+// teardown used to poison the rest: it aborted the loop, stranding every
+// container still queued behind it, and it escaped Main before it could exit
+// with the suite's own status.
+func TestTeardownRegistryContainsPanickingTeardown(t *testing.T) {
+	var r teardownRegistry
+
+	var ranAfter bool
+	// Registered first, so LIFO runs it last — after the panicking one.
+	r.add(func() error {
+		ranAfter = true
+		return nil
+	})
+	r.add(func() error { panic("boom") })
+
+	err := r.run()
+
+	if err == nil {
+		t.Error("run() = nil, want the panic reported")
+	}
+	if !ranAfter {
+		t.Error("a panicking teardown stopped the ones queued behind it")
+	}
+	if got := len(r.fns); got != 0 {
+		t.Errorf("len(r.fns) = %d after run, want 0 so a second call is a no-op", got)
+	}
+}
+
+// TestTeardownRegistryReportsErrors asserts a failed container termination
+// reaches Main, which turns it into a failing run rather than a swallowed write
+// to stdout.
+func TestTeardownRegistryReportsErrors(t *testing.T) {
+	var r teardownRegistry
+
+	sentinel := errors.New("terminate failed")
+	r.add(func() error { return sentinel })
+
+	if err := r.run(); !errors.Is(err, sentinel) {
+		t.Errorf("run() = %v, want it to wrap %v", err, sentinel)
+	}
+}


### PR DESCRIPTION
Migrations run once into a template DB per binary; each test gets an isolated namespace (Postgres template clone, ClickHouse per-test DB, NATS stream rebuild, Redis logical DB). Main tears down via a teardown registry and force-enables Ryuk so abnormal exits don't strand containers. Guards enforce TestMain wiring and no t.Parallel().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test performance by reusing shared test environments while preserving isolation between test cases.
  * Added automated checks to ensure test suites are configured consistently and avoid unsupported parallel execution.
  * Strengthened cleanup and recovery handling for test resources, including database, messaging, cache, and container services.

* **Documentation**
  * Expanded testing guidance with setup, isolation, teardown, concurrency, and short-test execution details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->