### PR TITLE
perf(usage): uncorrelate the unmetered-day delete, fold Reader into Service

### DIFF
--- a/internal/app/server/rpc/dashboard/usage/handler.go
+++ b/internal/app/server/rpc/dashboard/usage/handler.go
@@ -16,17 +16,13 @@ import (
 
 // Role gating is enforced by rpc.AuthzInterceptor before any handler runs, so a
 // request reaching here proves the org exists and the caller is a member.
-//
-// Holds a coreusage.Reader, not a Service: this endpoint is on the viewer floor
-// and every write in the usage package belongs to the meter, so the read side is
-// given a type with no reachable path to one.
 type Server struct {
-	service *coreusage.Reader
+	service *coreusage.Service
 }
 
-func NewServer(service *coreusage.Reader) *Server {
+func NewServer(service *coreusage.Service) *Server {
 	if service == nil {
-		panic("usage: reader is nil")
+		panic("usage: service is nil")
 	}
 	return &Server{service: service}
 }

--- a/internal/app/server/rpc/dashboard/usage/handler_test.go
+++ b/internal/app/server/rpc/dashboard/usage/handler_test.go
@@ -47,7 +47,7 @@ func TestGetUsageOmitsBothFieldsUntilMetered(t *testing.T) {
 	pg := testutil.SetupPostgres(t)
 	svc := coreusage.NewService(pg.PgRO, pg.PgW)
 	orgID, projectID := seedOrgProject(t, dbwrite.New(pg.PgW))
-	srv := NewServer(svc.Reader)
+	srv := NewServer(svc)
 
 	resp, err := srv.GetUsage(t.Context(), connect.NewRequest(&usagev1.GetUsageRequest{
 		OrgId: &orgID,
@@ -133,7 +133,7 @@ func TestGetUsageKeepsTheStampAcrossAMonthRollover(t *testing.T) {
 		t.Fatalf("RefreshPeriodUsage: %v", err)
 	}
 
-	resp, err := getUsage(t, NewServer(svc.Reader), orgID)
+	resp, err := getUsage(t, NewServer(svc), orgID)
 	if err != nil {
 		t.Fatalf("GetUsage: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestGetUsageRangeWindowsOnlyTheDailySeries(t *testing.T) {
 		t.Fatalf("RefreshPeriodUsage: %v", err)
 	}
 
-	srv := NewServer(svc.Reader)
+	srv := NewServer(svc)
 	resp, err := srv.GetUsage(t.Context(), connect.NewRequest(&usagev1.GetUsageRequest{
 		OrgId: &orgID,
 		Range: &commonv1.TimeRange{
@@ -214,7 +214,7 @@ func TestGetUsageRangeSnapsToWholeDays(t *testing.T) {
 		t.Fatalf("RecordDailyUsage: %v", err)
 	}
 
-	resp, err := NewServer(svc.Reader).GetUsage(t.Context(), connect.NewRequest(&usagev1.GetUsageRequest{
+	resp, err := NewServer(svc).GetUsage(t.Context(), connect.NewRequest(&usagev1.GetUsageRequest{
 		OrgId: &orgID,
 		Range: &commonv1.TimeRange{
 			From: timestamppb.New(day.Add(9 * time.Hour)),
@@ -251,7 +251,7 @@ func TestGetUsageFailsWhenTheReadFails(t *testing.T) {
 	pg := testutil.SetupPostgres(t)
 	svc := coreusage.NewService(pg.PgRO, pg.PgW)
 	orgID, _ := seedOrgProject(t, dbwrite.New(pg.PgW))
-	srv := NewServer(svc.Reader)
+	srv := NewServer(svc)
 
 	pg.PgRO.Close()
 
@@ -274,7 +274,7 @@ func TestGetUsageOnACancelledRequest(t *testing.T) {
 
 	pg := testutil.SetupPostgres(t)
 	orgID, _ := seedOrgProject(t, dbwrite.New(pg.PgW))
-	srv := NewServer(coreusage.NewReader(pg.PgRO))
+	srv := NewServer(coreusage.NewService(pg.PgRO, pg.PgW))
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -197,10 +197,10 @@ func start(ctx context.Context, d *deps) error {
 	customersPath, customersHandler := customersv1connect.NewCustomersServiceHandler(
 		customers.NewServer(corecustomers.NewService(d.pgW)), handlerOpts)
 
-	// Read-only by construction: no ClickHouse (the server only reads what
-	// `pug cron usage` stored) and no write pool at all.
+	// No ClickHouse: the server only reads what `pug cron usage` stored, and
+	// MeterWindow is the one method that needs it.
 	usagePath, usageHandler := usagev1connect.NewUsageServiceHandler(
-		usage.NewServer(coreusage.NewReader(d.pgRo)), handlerOpts)
+		usage.NewServer(coreusage.NewService(d.pgRo, d.pgW)), handlerOpts)
 
 	// Shared
 	insightsPath, insightsHandler := insightsv1connect.NewInsightsServiceHandler(

--- a/internal/core/usage/usage.go
+++ b/internal/core/usage/usage.go
@@ -21,26 +21,10 @@ import (
 	"github.com/pug-sh/pug/internal/slogx"
 )
 
-// Reader answers the dashboard's two usage questions and nothing else.
-//
-// The RPC handler holds one of these rather than a Service, so the endpoint
-// serving a viewer-floor read has no reachable path to PruneUsage or
-// DeleteUnmeteredDays. The meter owns every write in this package; giving the
-// read side a type that cannot perform one is cheaper than trusting it not to.
-// It also takes no write pool, because it never had a use for one.
-type Reader struct {
-	read *dbread.Queries
-}
-
-func NewReader(pgRO *pgxpool.Pool) *Reader {
-	return &Reader{read: dbread.New(pgRO)}
-}
-
-// Service is the meter's view: everything a Reader can do, plus the writes and
-// the reconcile. Only `pug cron usage` builds one.
+// Service is the whole package: the dashboard's two reads, plus the writes and
+// the reconcile the meter owns.
 type Service struct {
-	*Reader
-
+	read  *dbread.Queries
 	write *dbwrite.Queries
 
 	// Nil until WithClickHouse; only MeterWindow needs it.
@@ -51,7 +35,7 @@ type Service struct {
 // live on the result; only MeterWindow is gated. Metering additionally requires
 // WithClickHouse.
 func NewService(pgRO, pgW *pgxpool.Pool) *Service {
-	return &Service{Reader: NewReader(pgRO), write: dbwrite.New(pgW)}
+	return &Service{read: dbread.New(pgRO), write: dbwrite.New(pgW)}
 }
 
 // WithClickHouse returns a copy with the metering connection attached. Only
@@ -82,7 +66,7 @@ type PeriodUsage struct {
 }
 
 // GetPeriodUsage reads the pre-summed period total.
-func (s *Reader) GetPeriodUsage(ctx context.Context, orgID string, start time.Time) (PeriodUsage, error) {
+func (s *Service) GetPeriodUsage(ctx context.Context, orgID string, start time.Time) (PeriodUsage, error) {
 	row, err := s.read.GetUsagePeriod(ctx, dbread.GetUsagePeriodParams{
 		OrgID:       orgID,
 		PeriodStart: postgres.NewTimestamptz(start),
@@ -107,7 +91,7 @@ func (s *Reader) GetPeriodUsage(ctx context.Context, orgID string, start time.Ti
 // org's last stamp — otherwise every dashboard reads "never metered" on the 1st.
 // Counted stays false: the stamp says the meter is alive, not that it has summed
 // this period.
-func (s *Reader) periodNotReached(ctx context.Context, orgID string) (PeriodUsage, error) {
+func (s *Service) periodNotReached(ctx context.Context, orgID string) (PeriodUsage, error) {
 	at, err := s.read.GetLatestUsageComputedAt(ctx, orgID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -130,7 +114,7 @@ const MaxDailyRows = 10_000
 // ListDailyUsage returns the org's stored (project, day) cells over [from, to),
 // oldest first, at most MaxDailyRows of them. Bounds snap outwards to whole UTC
 // days.
-func (s *Reader) ListDailyUsage(ctx context.Context, orgID string, from, to time.Time) ([]DailyUsage, error) {
+func (s *Service) ListDailyUsage(ctx context.Context, orgID string, from, to time.Time) ([]DailyUsage, error) {
 	rows, err := s.read.ListUsageDailyByOrgID(ctx, dbread.ListUsageDailyByOrgIDParams{
 		FromDay:  postgres.NewDate(FloorDayUTC(from)),
 		OrgID:    orgID,

--- a/internal/gen/repo/dbwrite/usage.sql.go
+++ b/internal/gen/repo/dbwrite/usage.sql.go
@@ -14,11 +14,10 @@ import (
 const deleteUnmeteredUsageDaily = `-- name: DeleteUnmeteredUsageDaily :execrows
 delete from usage_daily d
 where d.day >= $1 and d.day < $2
-  and not exists (
-    select 1
+  and (d.project_id::text, d.day) not in (
+    select p.project_id, k.day
     from unnest($3::text[]) with ordinality as p(project_id, n)
     join unnest($4::date[]) with ordinality as k(day, n) on p.n = k.n
-    where p.project_id = d.project_id and k.day = d.day
   )
 `
 
@@ -32,6 +31,13 @@ type DeleteUnmeteredUsageDailyParams struct {
 // Cells the recompute no longer sees at all: their events were deleted (GDPR
 // erasure, a dropped partition). Upserting only what ClickHouse returned would
 // leave the old count standing forever.
+//
+// Uncorrelated on purpose. A `not exists` referencing d re-runs the unnest join
+// per candidate row, and unnest estimates 100 rows whatever the array holds, so
+// the planner picks a join filter and the cost becomes days x projects^2 -- tens
+// of seconds and gigabytes of temp spill once a full recompute widens the window
+// to a month. The arrays never contain NULL, so `not in` is exact here, and an
+// empty one still means "delete the whole window" exactly as before.
 func (q *Queries) DeleteUnmeteredUsageDaily(ctx context.Context, arg DeleteUnmeteredUsageDailyParams) (int64, error) {
 	result, err := q.db.Exec(ctx, deleteUnmeteredUsageDaily,
 		arg.FromDay,

--- a/schema/postgres/queries/write/usage.sql
+++ b/schema/postgres/queries/write/usage.sql
@@ -31,13 +31,19 @@ returning event_count;
 -- Cells the recompute no longer sees at all: their events were deleted (GDPR
 -- erasure, a dropped partition). Upserting only what ClickHouse returned would
 -- leave the old count standing forever.
+--
+-- Uncorrelated on purpose. A `not exists` referencing d re-runs the unnest join
+-- per candidate row, and unnest estimates 100 rows whatever the array holds, so
+-- the planner picks a join filter and the cost becomes days x projects^2 -- tens
+-- of seconds and gigabytes of temp spill once a full recompute widens the window
+-- to a month. The arrays never contain NULL, so `not in` is exact here, and an
+-- empty one still means "delete the whole window" exactly as before.
 delete from usage_daily d
 where d.day >= @from_day and d.day < @to_day
-  and not exists (
-    select 1
+  and (d.project_id::text, d.day) not in (
+    select p.project_id, k.day
     from unnest(@project_ids::text[]) with ordinality as p(project_id, n)
     join unnest(@days::date[]) with ordinality as k(day, n) on p.n = k.n
-    where p.project_id = d.project_id and k.day = d.day
   );
 
 -- name: PruneUsageDaily :execrows


### PR DESCRIPTION
Two independent usage cleanups, split out of the billing entitlement branch so they can land on their own.

`DeleteUnmeteredUsageDaily`'s correlated `not exists` re-ran the unnest join per candidate row, and unnest estimates 100 rows whatever the array actually holds — so once the 24h full recompute widened the window to a month, the planner picked a join filter and the cost went to days × projects². The arrays never contain NULL, so `not in` is exact here, and an empty one still means "delete the whole window" exactly as before.

`coreusage.Reader` was a read-only companion type that withheld the meter's writes from the RPC handler by construction. That is a second type per package to keep in step for a boundary `rpc.AuthzInterceptor` already enforces, so the handler holds the `Service` now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage data cleanup to more reliably remove obsolete daily records.
  * Preserved existing usage reporting behavior and error handling.
* **Refactor**
  * Consolidated usage reading and writing into a single service, improving consistency across dashboard usage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->