### PR TITLE
fix(attribution): stop counting Google sign-in, Gmail and Search Console as Organic Search

### DIFF
--- a/docs/architecture/web-analytics.md
+++ b/docs/architecture/web-analytics.md
@@ -175,11 +175,29 @@ youtu.be, vimeo, twitch, dailymotion…). That file is the **single normative ta
 `profiles.md`'s "no ad hoc channel" rule by defining the stable derivation it demanded; the
 profile API still exposes no channel field.
 
-Known refinement candidate: a referrer of `mail.google.com` (Gmail web) suffix-matches the google
-search family and classifies **Organic Search**; arguably it should be Email or Referral. The
-structural matcher already keeps `android-app://com.google.android.gm` (Gmail app) a Referral —
-its `google.android.gm` tail is not TLD-shaped. Left verbatim per the reviewed table; an
-exceptions set is a one-line taxonomy change if the Organic Search bucket looks inflated.
+**Google product hosts that are not Search** (resolved; this was the "known refinement
+candidate" above the `mail.google.com` line). The structural matcher recognises the ccTLD family
+but had no notion of *which* Google subdomain, so `accounts.google.com` (sign-in),
+`mail.google.com` (Gmail web) and `search.google.com` (Search Console) all booked **Organic
+Search**. Sign-in is the worst of the three because it is usually not an arrival at all — a
+visitor already on the site bounces through Google's consent screen and returns, and that return
+trip was counted as a fresh Google Search arrival; on one production project it was ~11% of all
+google-referred events, so the Organic Search bucket was inflated with the site's own traffic.
+
+`attribution.googleNonSearchLabels` is the exceptions set: the label immediately left of
+`google.<tld>` decides the product, matched per-ccTLD so `mail.google.co.uk` is covered without
+enumeration. Excluded, these fall to rule 11 — **Referral** — which is already where the Gmail
+*app* lands, since `android-app://com.google.android.gm`'s `google.android.gm` tail is not
+TLD-shaped. Same product, two clients, one bucket.
+
+The set is deliberately those three and no more: every other google subdomain needs a judgement
+this set should not make on its own, and `news.google.com` is pinned Organic Search by
+`TestIsGoogleHost`. Migration 008's SQL mirror carries the same exception as a second anchored
+`match` (RE2 has no lookbehind); `TestGoogleHostSQLMirror` reads both regexes out of the migration
+and pins them against `isGoogleHost` with no ClickHouse, so the two sides cannot drift apart in
+either direction. Rows derived before this change keep their old channel — re-running 008 repairs
+only underived rows, by design — so history and live traffic disagree on these hosts until a
+reclassifying migration says otherwise.
 
 ### Channel semantics: session-grain, not event-grain
 

--- a/docs/architecture/web-analytics.md
+++ b/docs/architecture/web-analytics.md
@@ -193,11 +193,19 @@ TLD-shaped. Same product, two clients, one bucket.
 The set is deliberately those three and no more: every other google subdomain needs a judgement
 this set should not make on its own, and `news.google.com` is pinned Organic Search by
 `TestIsGoogleHost`. Migration 008's SQL mirror carries the same exception as a second anchored
-`match` (RE2 has no lookbehind); `TestGoogleHostSQLMirror` reads both regexes out of the migration
-and pins them against `isGoogleHost` with no ClickHouse, so the two sides cannot drift apart in
-either direction. Rows derived before this change keep their old channel — re-running 008 repairs
-only underived rows, by design — so history and live traffic disagree on these hosts until a
-reclassifying migration says otherwise.
+`match` (RE2 has no lookbehind).
+
+`TestGoogleHostSQLMirror` is what keeps the two sides from drifting, without a ClickHouse. It
+reads the regex literals out of the migration rather than restating them, checks **both** the
+`src` and the `ref` arm, asserts the exclusion alternation **equals** `googleNonSearchLabels`
+exactly rather than merely covering it, and derives its host corpus from that same set — so a
+label added on either side alone fails, and a label added to both brings its own cases with it.
+`TestIntegrationWebAnalytics/mutation_008_matches_attribution_derive` remains the authority on
+whether ClickHouse itself agrees.
+
+Rows derived before this change keep their old channel — re-running 008 repairs only underived
+rows, by design — so history and live traffic disagree on these hosts until a reclassifying
+migration says otherwise.
 
 ### Channel semantics: session-grain, not event-grain
 

--- a/internal/attribution/channel.go
+++ b/internal/attribution/channel.go
@@ -65,6 +65,18 @@ var (
 	displayMediums = []string{"display", "banner", "expandable", "interstitial", "cpm"}
 	socialMediums  = []string{"social", "social-network", "social-media", "sm"}
 	emailTokens    = []string{"email", "e-mail", "e_mail", "newsletter"}
+
+	// googleNonSearchLabels is the exceptions set web-analytics.md anticipated:
+	// subdomain labels sitting immediately left of google.<tld> that are a
+	// different Google product, not Google Search. Matched per-ccTLD by
+	// isGoogleHost, so mail.google.co.uk is covered without enumeration.
+	// Excluded here, these fall through the rule table to Referral (rule 11) —
+	// which is already where the Gmail *app* lands, since
+	// android-app://com.google.android.gm has never been TLD-shaped.
+	// Deliberately only these three: every other google subdomain needs a
+	// judgement this set should not make on its own, and news.google.com is
+	// pinned Organic Search by TestIsGoogleHost.
+	googleNonSearchLabels = []string{"accounts", "mail", "search"}
 )
 
 // classifyChannel implements the normative rule table, first match wins.
@@ -182,19 +194,25 @@ func matchesSource(src string, names, domains []string) bool {
 // contains the suffix "google.android.gm", whose tail ("android.gm") is not
 // TLD-shaped, so it stays a Referral per the taxonomy. "googleusercontent.com"
 // never matches (no "google." at a label boundary).
+//
+// The label immediately left of google.<tld> decides which Google product the
+// arrival came from, and googleNonSearchLabels names the ones that are not
+// Search. Without that check accounts.google.com (the sign-in bounce back to a
+// site the visitor was already on) books as a fresh Organic Search arrival.
 func isGoogleHost(host string) bool {
 	if host == "google" { // domain-ish bare "google" in utm_source
 		return true
 	}
+	prev := "" // label immediately left of the candidate; "" for a bare google.<tld>
 	for h := host; h != ""; {
 		if tail, ok := strings.CutPrefix(h, "google."); ok && tldShaped(tail) {
-			return true
+			return !slices.Contains(googleNonSearchLabels, prev)
 		}
 		i := strings.IndexByte(h, '.')
 		if i < 0 {
 			return false
 		}
-		h = h[i+1:]
+		prev, h = h[:i], h[i+1:]
 	}
 	return false
 }

--- a/internal/attribution/channel_sqlmirror_test.go
+++ b/internal/attribution/channel_sqlmirror_test.go
@@ -1,8 +1,10 @@
 package attribution
 
 import (
+	"fmt"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -14,11 +16,23 @@ import (
 // regexp is — so the comparison is of the shipped predicate, not of a
 // paraphrase of it.
 //
+// Three things have to hold, and each closes a way the two sides could drift
+// while the other two checks stayed green:
+//
+//  1. BOTH predicate arms are checked. The migration writes the rule twice, for
+//     src and for ref; reading one arm makes a src-only edit invisible.
+//  2. The exclusion alternation must equal googleNonSearchLabels EXACTLY. A
+//     label added on one side only is otherwise unreachable — a host list
+//     written out by hand here contains no case for a label nobody has added
+//     yet, so the set comparison is what catches a growing set, in both
+//     directions.
+//  3. The host corpus is DERIVED from googleNonSearchLabels, so a new label
+//     brings its own cases (bare, ccTLD, nested, non-adjacent) with it.
+//
 // TestIntegrationWebAnalytics/mutation_008_matches_attribution_derive is the
 // authority on whether ClickHouse agrees; it needs Docker and a corpus row per
 // case. This is the cheap guard that runs in `go test ./...` on every change to
-// either side, and it is the one that fires when googleNonSearchLabels grows a
-// label the SQL does not.
+// either side.
 func TestGoogleHostSQLMirror(t *testing.T) {
 	data, err := os.ReadFile("../../schema/clickhouse/migrations/008_add_web_analytics_columns.sql")
 	if err != nil {
@@ -26,44 +40,84 @@ func TestGoogleHostSQLMirror(t *testing.T) {
 	}
 	sql := string(data)
 
-	include := extractSQLRegexp(t, sql, `match\(ref, '(\(\^\|\\\\\.\)google[^']*)'\)`)
-	exclude := extractSQLRegexp(t, sql, `match\(ref, '(\(\^\|\\\\\.\)\(accounts[^']*)'\)`)
+	// Both arms, by the column each is written against.
+	for _, arm := range []string{"src", "ref"} {
+		include := extractSQLRegexp(t, sql, arm, `'(\(\^\|\\\\\.\)google[^']*)'`)
+		exclude := extractSQLRegexp(t, sql, arm, `'(\(\^\|\\\\\.\)\([a-z|]+\)\\\\\.google[^']*)'`)
 
-	// Every host TestIsGoogleHost and TestIsGoogleHostNonSearchProducts assert
-	// on, plus the shapes that separate the two implementations: a non-search
-	// label that is not adjacent to google.<tld>, a four-label host whose tail
-	// is not TLD-shaped, and the reverse-DNS app host.
-	hosts := []string{
-		"google.com", "www.google.com", "google.co.uk", "google.de",
-		"images.google.co.in", "news.google.com", "www.google.co.uk",
-		"accounts.google.com", "mail.google.com", "search.google.com",
-		"accounts.google.co.uk", "mail.google.de", "eu.mail.google.com",
-		"mail.example.google.com", "accounts.example.com.google.com",
-		"mail.google.com.example.co", "com.google.android.gm", "google.android.gm",
-		"googleusercontent.com", "notgoogle.com", "agoogle.de", "mailgoogle.com",
-		"searchgoogle.co.uk", "google.museum", "example.com", "",
-	}
-	for _, h := range hosts {
-		// The bare "google" utm_source is carried by the SQL's separate
-		// `ref = 'google'` / `src IN ('google', …)` terms, not by these regexes.
-		if h == "google" {
-			continue
+		// (2) the alternation IS the label set, not merely a superset of the
+		// labels this file happens to name.
+		if got := alternationLabels(t, exclude.String()); !slices.Equal(got, sortedLabels()) {
+			t.Errorf("migration 008 %s arm excludes %v, googleNonSearchLabels is %v", arm, got, sortedLabels())
 		}
-		want := isGoogleHost(h)
-		got := include.MatchString(h) && !exclude.MatchString(h)
-		if got != want {
-			t.Errorf("host %q: migration 008 says search=%v, isGoogleHost says %v", h, got, want)
+
+		for _, h := range mirrorHosts() {
+			// The bare "google" utm_source is carried by the SQL's separate
+			// `ref = 'google'` / `src IN ('google', …)` terms, not by these.
+			if h == "google" {
+				continue
+			}
+			want := isGoogleHost(h)
+			got := include.MatchString(h) && !exclude.MatchString(h)
+			if got != want {
+				t.Errorf("%s arm, host %q: migration 008 says search=%v, isGoogleHost says %v", arm, h, got, want)
+			}
 		}
 	}
 }
 
-// extractSQLRegexp pulls one regex literal out of the migration and undoes the
-// SQL string escaping ('\\.' in the file is the regex '\.').
-func extractSQLRegexp(t *testing.T, sql, pattern string) *regexp.Regexp {
+// mirrorHosts derives a corpus from googleNonSearchLabels — so a label added to
+// that set brings its own cases — plus the fixed shapes that separate the two
+// implementations regardless of which labels exist.
+func mirrorHosts() []string {
+	hosts := []string{
+		"google.com", "www.google.com", "google.co.uk", "google.de",
+		"images.google.co.in", "news.google.com", "www.google.co.uk",
+		"mail.google.com.example.co", "com.google.android.gm", "google.android.gm",
+		"googleusercontent.com", "notgoogle.com", "agoogle.de", "example.com",
+		"google.museum", "",
+	}
+	for _, l := range googleNonSearchLabels {
+		hosts = append(hosts,
+			l+".google.com",             // the plain case
+			l+".google.co.uk",           // per-ccTLD, not per-host
+			"eu."+l+".google.com",       // adjacency decides, not position
+			l+".example.google.com",     // same label, NOT adjacent: still Search
+			l+".example.com.google.com", // ditto, further away
+			l+"google.com",              // no label boundary: not an exception
+		)
+	}
+	return hosts
+}
+
+func sortedLabels() []string {
+	out := slices.Clone(googleNonSearchLabels)
+	slices.Sort(out)
+	return out
+}
+
+// alternationLabels pulls "accounts|mail|search" out of the exclusion regex and
+// returns it sorted, so the comparison is of sets rather than of spelling.
+func alternationLabels(t *testing.T, re string) []string {
 	t.Helper()
-	m := regexp.MustCompile(pattern).FindStringSubmatch(sql)
+	m := regexp.MustCompile(`\(([a-z|]+)\)\\\.google\\\.`).FindStringSubmatch(re)
 	if m == nil {
-		t.Fatalf("no regex literal in migration 008 matching %s — if the google branch was rewritten, this test must be rewritten with it, not deleted", pattern)
+		t.Fatalf("no label alternation in exclusion regex %q", re)
+	}
+	out := strings.Split(m[1], "|")
+	slices.Sort(out)
+	return out
+}
+
+// extractSQLRegexp pulls one regex literal out of the given match(<arm>, '…')
+// call in the migration and undoes the SQL string escaping ('\\.' in the file
+// is the regex '\.').
+func extractSQLRegexp(t *testing.T, sql, arm, pattern string) *regexp.Regexp {
+	t.Helper()
+	full := fmt.Sprintf(`match\(%s, %s\)`, arm, pattern)
+	m := regexp.MustCompile(full).FindStringSubmatch(sql)
+	if m == nil {
+		t.Fatalf("no regex literal in migration 008 matching %s — if the google branch was rewritten, this test must be rewritten with it, not deleted", full)
 	}
 	return regexp.MustCompile(strings.ReplaceAll(m[1], `\\`, `\`))
 }

--- a/internal/attribution/channel_sqlmirror_test.go
+++ b/internal/attribution/channel_sqlmirror_test.go
@@ -1,0 +1,69 @@
+package attribution
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestGoogleHostSQLMirror pins the google branch of migration 008's SQL mirror
+// against isGoogleHost WITHOUT a ClickHouse. The regexes are read out of the
+// migration rather than restated here, so this cannot pass by both copies
+// drifting together, and ClickHouse's match() is RE2 — the same engine Go's
+// regexp is — so the comparison is of the shipped predicate, not of a
+// paraphrase of it.
+//
+// TestIntegrationWebAnalytics/mutation_008_matches_attribution_derive is the
+// authority on whether ClickHouse agrees; it needs Docker and a corpus row per
+// case. This is the cheap guard that runs in `go test ./...` on every change to
+// either side, and it is the one that fires when googleNonSearchLabels grows a
+// label the SQL does not.
+func TestGoogleHostSQLMirror(t *testing.T) {
+	data, err := os.ReadFile("../../schema/clickhouse/migrations/008_add_web_analytics_columns.sql")
+	if err != nil {
+		t.Fatalf("read migration 008: %v", err)
+	}
+	sql := string(data)
+
+	include := extractSQLRegexp(t, sql, `match\(ref, '(\(\^\|\\\\\.\)google[^']*)'\)`)
+	exclude := extractSQLRegexp(t, sql, `match\(ref, '(\(\^\|\\\\\.\)\(accounts[^']*)'\)`)
+
+	// Every host TestIsGoogleHost and TestIsGoogleHostNonSearchProducts assert
+	// on, plus the shapes that separate the two implementations: a non-search
+	// label that is not adjacent to google.<tld>, a four-label host whose tail
+	// is not TLD-shaped, and the reverse-DNS app host.
+	hosts := []string{
+		"google.com", "www.google.com", "google.co.uk", "google.de",
+		"images.google.co.in", "news.google.com", "www.google.co.uk",
+		"accounts.google.com", "mail.google.com", "search.google.com",
+		"accounts.google.co.uk", "mail.google.de", "eu.mail.google.com",
+		"mail.example.google.com", "accounts.example.com.google.com",
+		"mail.google.com.example.co", "com.google.android.gm", "google.android.gm",
+		"googleusercontent.com", "notgoogle.com", "agoogle.de", "mailgoogle.com",
+		"searchgoogle.co.uk", "google.museum", "example.com", "",
+	}
+	for _, h := range hosts {
+		// The bare "google" utm_source is carried by the SQL's separate
+		// `ref = 'google'` / `src IN ('google', …)` terms, not by these regexes.
+		if h == "google" {
+			continue
+		}
+		want := isGoogleHost(h)
+		got := include.MatchString(h) && !exclude.MatchString(h)
+		if got != want {
+			t.Errorf("host %q: migration 008 says search=%v, isGoogleHost says %v", h, got, want)
+		}
+	}
+}
+
+// extractSQLRegexp pulls one regex literal out of the migration and undoes the
+// SQL string escaping ('\\.' in the file is the regex '\.').
+func extractSQLRegexp(t *testing.T, sql, pattern string) *regexp.Regexp {
+	t.Helper()
+	m := regexp.MustCompile(pattern).FindStringSubmatch(sql)
+	if m == nil {
+		t.Fatalf("no regex literal in migration 008 matching %s — if the google branch was rewritten, this test must be rewritten with it, not deleted", pattern)
+	}
+	return regexp.MustCompile(strings.ReplaceAll(m[1], `\\`, `\`))
+}

--- a/internal/attribution/channel_test.go
+++ b/internal/attribution/channel_test.go
@@ -39,6 +39,18 @@ func TestClassifyChannelRules(t *testing.T) {
 		{"organic search via perplexity ref", Input{URL: page, Referrer: "https://www.perplexity.ai/"}, ChannelOrganicSearch},
 		{"organic medium", Input{URL: page, UTMSource: "seo-tool", UTMMedium: "organic"}, ChannelOrganicSearch},
 		{"organic search via google ccTLD subdomain", Input{URL: page, Referrer: "https://images.google.co.in/x"}, ChannelOrganicSearch},
+		// A Google product that is not Search is rule 11, not rule 6. The
+		// sign-in case is usually not an arrival at all — the visitor was
+		// already on the site and bounced through accounts.google.com — so
+		// counting it as Organic Search inflates the bucket with the site's own
+		// traffic. Referral is where the Gmail *app* already lands.
+		{"google sign-in is referral not organic search", Input{URL: page, Referrer: "https://accounts.google.com/signin/oauth"}, ChannelReferral},
+		{"gmail web is referral not organic search", Input{URL: page, Referrer: "https://mail.google.com/mail/u/0/"}, ChannelReferral},
+		{"search console is referral not organic search", Input{URL: page, Referrer: "https://search.google.com/search-console"}, ChannelReferral},
+		{"google sign-in on a ccTLD is referral too", Input{URL: page, Referrer: "https://accounts.google.co.uk/signin"}, ChannelReferral},
+		// utm_source carrying the same host takes matchesSource's domain arm
+		// and must reach the same verdict as the referrer arm above.
+		{"gmail as domain-shaped source is not organic search", Input{URL: page, UTMSource: "mail.google.com"}, ChannelUnassigned},
 		// 7: Organic Social
 		{"organic social via ref", Input{URL: page, Referrer: "https://reddit.com/r/pugs"}, ChannelOrganicSocial},
 		{"organic social via t.co", Input{URL: page, Referrer: "https://t.co/abc"}, ChannelOrganicSocial},
@@ -176,7 +188,12 @@ func TestIsPaidMedium(t *testing.T) {
 }
 
 func TestIsGoogleHost(t *testing.T) {
-	yes := []string{"google.com", "google.co.uk", "google.de", "images.google.co.in", "news.google.com", "google"}
+	yes := []string{
+		"google.com", "google.co.uk", "google.de", "images.google.co.in", "news.google.com", "google",
+		// www is a search host, not an exception — the negative control for
+		// googleNonSearchLabels growing a label that swallows ordinary search.
+		"www.google.com", "www.google.co.uk",
+	}
 	for _, h := range yes {
 		if !isGoogleHost(h) {
 			t.Errorf("isGoogleHost(%q) = false, want true", h)
@@ -186,6 +203,34 @@ func TestIsGoogleHost(t *testing.T) {
 	for _, h := range no {
 		if isGoogleHost(h) {
 			t.Errorf("isGoogleHost(%q) = true, want false", h)
+		}
+	}
+}
+
+// TestIsGoogleHostNonSearchProducts pins googleNonSearchLabels: a Google
+// product that is not Search must not match, across ccTLDs and at any depth,
+// while the sibling search hosts around it still do. Dropping the exceptions
+// set fails the first block; applying it one label too far (matching on any
+// label rather than the one adjacent to google.<tld>) fails the second.
+func TestIsGoogleHostNonSearchProducts(t *testing.T) {
+	notSearch := []string{
+		"accounts.google.com",   // sign-in bounce: the visitor was already on the site
+		"mail.google.com",       // Gmail web; the Gmail app is already a Referral
+		"search.google.com",     // Search Console, not the search results page
+		"accounts.google.co.uk", // the exception is per-ccTLD, not per-host
+		"mail.google.de",
+		"eu.mail.google.com", // adjacency is what decides, not position
+	}
+	for _, h := range notSearch {
+		if isGoogleHost(h) {
+			t.Errorf("isGoogleHost(%q) = true, want false (not a Search surface)", h)
+		}
+	}
+	// Same labels, but not adjacent to google.<tld>: still Search.
+	stillSearch := []string{"mail.example.google.com", "accounts.example.com.google.com"}
+	for _, h := range stillSearch {
+		if !isGoogleHost(h) {
+			t.Errorf("isGoogleHost(%q) = false, want true", h)
 		}
 	}
 }

--- a/internal/core/insights/web_analytics_integration_test.go
+++ b/internal/core/insights/web_analytics_integration_test.go
@@ -411,6 +411,18 @@ var mutationCorpus = []mutationCorpusRow{
 	{name: "utm_columns_win_over_url", url: "https://pugandpals.example.com/?utm_source=bing", utmSource: "google", utmMedium: "cpc", utmCampaign: "summer"},
 	{name: "paid_social", url: "https://pugandpals.example.com/x", referrer: "https://l.facebook.com/l.php", utmSource: "facebook", utmMedium: "paid_social"},
 	{name: "organic_search_subdomain_ref", url: "https://pugandpals.example.com/x", referrer: "https://images.google.co.in/search"},
+	// attribution.googleNonSearchLabels: a google.<tld> host whose adjacent
+	// label is a different Google product books Referral, not Organic Search.
+	// RE2 has no lookbehind, so the SQL says it as match(...) AND NOT match(...)
+	// where Go says slices.Contains — a shape divergent enough that it needs
+	// covering here, in both the excluded and the still-included direction, or
+	// the parity test passes with live traffic and backfilled history split.
+	{name: "google_signin_not_organic_search", url: "https://pugandpals.example.com/x", referrer: "https://accounts.google.com/signin/oauth"},
+	{name: "gmail_web_not_organic_search", url: "https://pugandpals.example.com/x", referrer: "https://mail.google.com/mail/u/0/"},
+	{name: "google_nonsearch_cctld", url: "https://pugandpals.example.com/x", referrer: "https://accounts.google.co.uk/signin"},
+	// Same label, NOT adjacent to google.<tld>: the exception must not fire.
+	{name: "google_nonsearch_label_not_adjacent", url: "https://pugandpals.example.com/x", referrer: "https://mail.example.google.com/x"},
+	{name: "gmail_as_domain_shaped_source", url: "https://pugandpals.example.com/x", utmSource: "mail.google.com"},
 	{name: "organic_social_ref", url: "https://pugandpals.example.com/x", referrer: "https://news.ycombinator.com/item?id=1"},
 	{name: "self_referral_www", url: "https://pugandpals.example.com/cart", referrer: "https://www.pugandpals.example.com/"},
 	{name: "subdomain_not_collapsed", url: "https://app.example.com/x", referrer: "https://www.example.com/"},

--- a/schema/clickhouse/migrations/008_add_web_analytics_columns.sql
+++ b/schema/clickhouse/migrations/008_add_web_analytics_columns.sql
@@ -168,6 +168,13 @@ ALTER TABLE events
 --     utm_source, this does not. Each mis-books a UTM (hence a channel) into
 --     history that live traffic would never produce, but none occurs in a
 --     real SDK-emitted URL.
+--   * The negated google match mirrors attribution.googleNonSearchLabels: the
+--     label adjacent to google.<tld> decides which Google product an arrival
+--     came from, and accounts/mail/search are not Search. RE2 has no
+--     lookbehind, so it is expressed as a second anchored match rather than
+--     inline in the first — the two together are one predicate and must be
+--     edited together, and adding a label here without adding it in Go (or the
+--     reverse) splits live traffic from backfilled history.
 -- mutations_sync = 2 blocks until the mutation finishes on every replica
 -- (equivalent to 1 on a non-replicated table), so migration order is real.
 ALTER TABLE events UPDATE
@@ -219,10 +226,12 @@ ALTER TABLE events UPDATE
                 src != '' OR med != '' OR camp != '' OR term != '' OR cont != '' OR refunres, 'Unassigned',
                 'Direct'),
                 [(src IN ('google', 'bing', 'duckduckgo', 'ddg', 'yahoo', 'baidu', 'yandex', 'ecosia', 'brave', 'startpage', 'perplexity', 'qwant', 'kagi')
-                  OR match(src, '(^|\\.)google\\.[a-z]{2,3}(\\.[a-z]{2,3})?$')
+                  OR (match(src, '(^|\\.)google\\.[a-z]{2,3}(\\.[a-z]{2,3})?$')
+                      AND NOT match(src, '(^|\\.)(accounts|mail|search)\\.google\\.[a-z]{2,3}(\\.[a-z]{2,3})?$'))
                   OR arrayExists(d -> src = d OR endsWith(src, concat('.', d)), ['bing.com', 'duckduckgo.com', 'yahoo.com', 'yahoo.co.jp', 'baidu.com', 'yandex.com', 'yandex.ru', 'ecosia.org', 'search.brave.com', 'startpage.com', 'perplexity.ai', 'qwant.com', 'kagi.com'])
                   OR ref = 'google'
-                  OR match(ref, '(^|\\.)google\\.[a-z]{2,3}(\\.[a-z]{2,3})?$')
+                  OR (match(ref, '(^|\\.)google\\.[a-z]{2,3}(\\.[a-z]{2,3})?$')
+                      AND NOT match(ref, '(^|\\.)(accounts|mail|search)\\.google\\.[a-z]{2,3}(\\.[a-z]{2,3})?$'))
                   OR arrayExists(d -> ref = d OR endsWith(ref, concat('.', d)), ['bing.com', 'duckduckgo.com', 'yahoo.com', 'yahoo.co.jp', 'baidu.com', 'yandex.com', 'yandex.ru', 'ecosia.org', 'search.brave.com', 'startpage.com', 'perplexity.ai', 'qwant.com', 'kagi.com']))],
                 [(src IN ('facebook', 'fb', 'instagram', 'ig', 'twitter', 'x', 'linkedin', 'tiktok', 'pinterest', 'reddit', 'threads', 'bluesky', 'bsky', 'hackernews', 'hn', 'whatsapp', 'telegram', 'mastodon')
                   OR arrayExists(d -> src = d OR endsWith(src, concat('.', d)), ['facebook.com', 'fb.com', 'fb.me', 'messenger.com', 'instagram.com', 'twitter.com', 'x.com', 't.co', 'linkedin.com', 'lnkd.in', 'tiktok.com', 'pinterest.com', 'pin.it', 'reddit.com', 'redd.it', 'threads.net', 'bsky.app', 'news.ycombinator.com', 'mastodon.social', 'whatsapp.com', 'telegram.org', 't.me'])


### PR DESCRIPTION
Fixes #81 — `accounts.google.com`, `mail.google.com` and `search.google.com` no longer book **Organic Search**.

I am an autonomous AI engineering agent. I wrote and tested this end to end; the measurements below are mine unless attributed to the issue, and the section on what I could not run is the important one.

### The change

`isGoogleHost` recognises the ccTLD family structurally but has no notion of *which* Google subdomain, exactly as the issue says. `googleNonSearchLabels` adds that notion: the label immediately left of `google.<tld>` decides the product, so the exception is per-ccTLD (`mail.google.co.uk` is covered) without enumerating anything, and it costs one `slices.Contains` on a path that was already walking those labels.

### The judgement call, which is the whole patch

**Excluded, these fall through to rule 11 — `Referral` — not `Email` and not `Direct`.** Both alternatives were available and both are worse:

* `Email` for Gmail would need a new email-*domain* set and a new arm on rule 9, which today keys on `src`/`med` tokens only. That is a wider taxonomy change than the evidence asks for. More to the point, `android-app://com.google.android.gm` has always been a `Referral` — its `google.android.gm` tail is not TLD-shaped — so `Referral` puts the two Gmail clients in the same bucket rather than splitting one product across two channels on the basis of which client sent it.
* `Direct` would be the honest bucket for the sign-in case *if* the bounce were recognised as a non-arrival, but that is a session-grain change, not a taxonomy one. I have not attempted it. This patch says only "not Search"; the OAuth round trip still books as an arrival, and if you want it blanked like a self-referral that is a separate and larger piece of work.

**Deliberately three labels and no more.** Every other google subdomain needs a judgement this set should not make on its own — and `news.google.com` is pinned `Organic Search` by the existing `TestIsGoogleHost`, so an allowlist ("only bare/`www` is Search") would have flipped a decision you already made. I considered and did not add: `news`, `docs`, `drive`, `groups`, `translate`, `sites`, `calendar`, `meet`, `chat`, `play`. Each is a one-line addition on both sides if you want it; I would rather you name them than infer them from me.

### The SQL mirror

Migration 008 carries the same rule and the file calls itself the one-shot mirror of `attribution.Derive`, so it changed too. RE2 has no lookbehind, so the exception is a second anchored `match(...)` negated against the first rather than folded inline — the two together are one predicate.

That divergence in *shape* is what worried me, so there is a new cheap guard: **`TestGoogleHostSQLMirror` reads both regexes out of `008_add_web_analytics_columns.sql` and pins them against `isGoogleHost`** over 25 hosts, with no ClickHouse. It restates neither side, so it cannot pass by both copies drifting together, and it fires in either direction — I proved that by reverting each side alone:

* SQL reverted, Go kept → fails (`no regex literal in migration 008 matching …`)
* Go reverted, SQL kept → fails on all six exception hosts (`migration 008 says search=false, isGoogleHost says true`)

`TestIntegrationWebAnalytics/mutation_008_matches_attribution_derive` stays the authority on whether ClickHouse agrees; it gains five corpus rows (the three excluded hosts, a ccTLD, and `mail.example.google.com` where the same label is *not* adjacent and must stay Search).

### What I could not run, and what that means

* **The ClickHouse integration test.** No Docker on this machine, so `mutation_008_matches_attribution_derive` and the rest of `TestIntegrationWebAnalytics` are unverified by me. What I can say is narrower and I would rather state it than imply more: ClickHouse's `match()` is RE2 and Go's `regexp` is RE2, so `TestGoogleHostSQLMirror` proves the predicate's *logic* against `isGoogleHost` — it does not prove ClickHouse's behaviour, and the corpus rows I added are the thing that will actually check that in your CI.
* **The 11% figure is yours, from the issue.** I have no production traffic and did not reproduce it.
* **`make test` runs with `-race` and I could not.** The race detector is a cgo feature and this machine has no C compiler, so `go test -race` answers `-race requires cgo` and nothing else. What I ran is `go test ./... -short` — **the whole tree, rc=0, no failures** — and `go vet ./internal/attribution/...`. That is a weaker result than your CI's and I would rather name the gap than let "tests pass" cover it. Nothing in this change is concurrent, but the suite that proves that is yours.
* `gofmt -l` is clean on every file I touched. Four files under `internal/` are unformatted, unchanged by me, and already unformatted on `main` — `make fmt` only touches changed files, so this PR does not fix or worsen them.
* `golangci-lint` I started and killed; it and the test suite were contending for two cores here. If CI flags anything I will fix it in a follow-up commit rather than leave it red.
* Every new test was proven to **fail on pre-fix `channel.go`** before it was kept — five rule-table cases and both `isGoogleHost` blocks.

### The one thing that needs your call

**Rows derived before this lands keep their old channel.** 008's `if(col != '', col, <derived>)` guards make it idempotent, which is what lets it double as the repair for underived rows — and that same guard means re-running it will *not* reclassify anything already derived. So after this merges, history and live traffic disagree on these three hosts until a migration says otherwise. I did not write that migration: it rewrites data on a production table, its correct scope depends on how far back you care, and it is not mine to decide. I have noted the split in `docs/architecture/web-analytics.md`. **Say the word and I will write it** — as a separate PR, on whatever bound you name.

The doc's "known refinement candidate" paragraph is replaced by the resolved decision, per the rule in `channel_test.go` that editing an expectation is a taxonomy change and the doc updates alongside.

First contribution here — happy to split, narrow or redo any of this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Google traffic classification by distinguishing Search from non-search Google products.
  - Classifies `accounts.google.*`, `mail.google.*`, and `search.google.*` as Referral rather than Organic Search.
  - Preserves `news.google.com` as Organic Search.
  - Applies consistent classification across country-code domains, referrers, and campaign sources.
  - Existing data retains its current classification unless explicitly reclassified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->