### PR TITLE
chore: apply Go 1.26 modernize fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,6 +113,10 @@ linters:
         - G115
     perfsprint:
       strconcat: false
+    modernize:
+      # newexpr would rewrite every proto.String/Bool helper into new(x): ~1350
+      # call sites of churn, and new(x) loses the idiom that marks an optional field.
+      disable: [newexpr]
 
   exclusions:
     generated: lax

--- a/internal/app/migrate/clickhouse/clickhouse.go
+++ b/internal/app/migrate/clickhouse/clickhouse.go
@@ -68,7 +68,7 @@ func Down(ctx context.Context, num int) error {
 		return nil
 	}
 
-	for i := 0; i < num; i++ {
+	for range num {
 		if err := goose.DownContext(ctx, db, dir); err != nil {
 			return err
 		}

--- a/internal/app/migrate/postgres/postgres.go
+++ b/internal/app/migrate/postgres/postgres.go
@@ -68,7 +68,7 @@ func Down(ctx context.Context, num int) error {
 		return nil
 	}
 
-	for i := 0; i < num; i++ {
+	for range num {
 		if err := goose.DownContext(ctx, db, dir); err != nil {
 			return err
 		}

--- a/internal/app/seed/clickhouse/seed_test.go
+++ b/internal/app/seed/clickhouse/seed_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"math/rand/v2"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -238,13 +239,7 @@ func TestAppVersionAdoption(t *testing.T) {
 	for range 5000 {
 		v := appVersionAt(at)
 		counts[v]++
-		found := false
-		for _, rv := range released {
-			if v == rv {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(released, v)
 		if !found {
 			t.Fatalf("appVersionAt returned unreleased version %s", v)
 		}
@@ -548,7 +543,7 @@ func TestToLiveEventsCopiesAllFields(t *testing.T) {
 	if le.AutoProperties["$k"] != "v" || le.CustomProperties["amount"] != 1.0 {
 		t.Fatalf("property maps not copied: %+v", le)
 	}
-	if ne, nl := reflect.TypeOf(event{}).NumField(), reflect.TypeOf(LiveEvent{}).NumField(); ne != nl {
+	if ne, nl := reflect.TypeFor[event]().NumField(), reflect.TypeFor[LiveEvent]().NumField(); ne != nl {
 		t.Errorf("event has %d fields, LiveEvent has %d — toLiveEvents must map all of them", ne, nl)
 	}
 }

--- a/internal/app/server/deps.go
+++ b/internal/app/server/deps.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -71,8 +72,8 @@ func newDeps(ctx context.Context) (*deps, error) {
 	success := false
 	defer func() {
 		if !success {
-			for i := len(closers) - 1; i >= 0; i-- {
-				closers[i]()
+			for _, closer := range slices.Backward(closers) {
+				closer()
 			}
 		}
 	}()

--- a/internal/app/server/rpc/authz_interceptor_test.go
+++ b/internal/app/server/rpc/authz_interceptor_test.go
@@ -31,8 +31,7 @@ func mustAuthorizer(t *testing.T) *authz.Authorizer {
 // path) or a plain *connect.Error — connect.CodeOf alone returns Unknown for the
 // former.
 func apperrCode(err error) connect.Code {
-	var ae *apperr.Error
-	if errors.As(err, &ae) {
+	if ae, ok := errors.AsType[*apperr.Error](err); ok {
 		return ae.Code()
 	}
 	return connect.CodeOf(err)

--- a/internal/app/server/rpc/authz_served.go
+++ b/internal/app/server/rpc/authz_served.go
@@ -53,8 +53,8 @@ var servedServices = []struct {
 func servedProcedures() map[string]bool {
 	procs := map[string]bool{}
 	for _, svc := range servedServices {
-		for i := 0; i < svc.handler.NumMethod(); i++ {
-			procs["/"+svc.name+"/"+svc.handler.Method(i).Name] = true
+		for method := range svc.handler.Methods() {
+			procs["/"+svc.name+"/"+method.Name] = true
 		}
 	}
 	return procs

--- a/internal/app/server/rpc/dashboard/dashboards/handler_test.go
+++ b/internal/app/server/rpc/dashboard/dashboards/handler_test.go
@@ -415,8 +415,7 @@ func assertCode(t *testing.T, err error, want connect.Code) {
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
-	var ae *apperr.Error
-	if errors.As(err, &ae) {
+	if ae, ok := errors.AsType[*apperr.Error](err); ok {
 		if ae.Code() != want {
 			t.Errorf("got code %v, want %v (err: %v)", ae.Code(), want, err)
 		}

--- a/internal/app/server/rpc/dashboard/orgs/handler_test.go
+++ b/internal/app/server/rpc/dashboard/orgs/handler_test.go
@@ -1063,7 +1063,7 @@ func TestResendInviteHandler_SendLimitReturnsFailedPrecondition(t *testing.T) {
 
 	// The fixture's invitation was already sent once, so the window allows
 	// maxInviteSendsPerWindow-1 resends before it trips.
-	for i := 0; i < 9; i++ {
+	for i := range 9 {
 		if _, err := srv.ResendInvite(ctx, req()); err != nil {
 			t.Fatalf("ResendInvite %d: %v", i, err)
 		}

--- a/internal/app/server/rpc/dashboard/projects/handler_test.go
+++ b/internal/app/server/rpc/dashboard/projects/handler_test.go
@@ -52,8 +52,7 @@ func assertCode(t *testing.T, err error, want connect.Code) {
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
-	var ae *apperr.Error
-	if errors.As(err, &ae) {
+	if ae, ok := errors.AsType[*apperr.Error](err); ok {
 		if ae.Code() != want {
 			t.Errorf("got code %v, want %v (err: %v)", ae.Code(), want, err)
 		}

--- a/internal/app/server/rpc/public/dashboards/handler_test.go
+++ b/internal/app/server/rpc/public/dashboards/handler_test.go
@@ -161,8 +161,7 @@ func assertCode(t *testing.T, err error, want connect.Code) {
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
-	var ae *apperr.Error
-	if errors.As(err, &ae) {
+	if ae, ok := errors.AsType[*apperr.Error](err); ok {
 		if ae.Code() != want {
 			t.Errorf("got code %v, want %v (err: %v)", ae.Code(), want, err)
 		}

--- a/internal/app/server/rpc/shared/activity/handler.go
+++ b/internal/app/server/rpc/shared/activity/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"maps"
 	"time"
 
 	"connectrpc.com/connect"
@@ -204,9 +205,7 @@ func eventsToProto(ctx context.Context, evts []events.Event, projectID string) (
 
 func mapToStruct(m map[string]any) (*structpb.Struct, error) {
 	fields := make(map[string]any, len(m))
-	for k, v := range m {
-		fields[k] = v
-	}
+	maps.Copy(fields, m)
 	return structpb.NewStruct(fields)
 }
 

--- a/internal/app/server/rpc/shared/insights/handler.go
+++ b/internal/app/server/rpc/shared/insights/handler.go
@@ -63,8 +63,7 @@ func (s *server) Query(
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, rpc.ConnectCtxErr(err)
 		}
-		var invalid *coreinsights.InvalidQueryError
-		if errors.As(err, &invalid) {
+		if invalid, ok := errors.AsType[*coreinsights.InvalidQueryError](err); ok {
 			return nil, apperr.Invalid(apperr.ReasonInvalidInsightQuery, "invalid query parameters: "+invalid.Message)
 		}
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))

--- a/internal/app/workers/email/processor_test.go
+++ b/internal/app/workers/email/processor_test.go
@@ -54,7 +54,7 @@ func TestProcessorMagicLinkIdempotencyKeyIsStableOnRetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("proto.Marshal: %v", err)
 	}
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		if err := processor.ProcessMessage(context.Background(), data); err != nil {
 			t.Fatalf("ProcessMessage attempt %d: %v", i, err)
 		}

--- a/internal/attribution/attribution_test.go
+++ b/internal/attribution/attribution_test.go
@@ -31,8 +31,8 @@ func TestOutputPairsCoversEveryField(t *testing.T) {
 		}
 		seen[p.Value] = true
 	}
-	for i := range rt.NumField() {
-		if name := rt.Field(i).Name; !seen[name] {
+	for field := range rt.Fields() {
+		if name := field.Name; !seen[name] {
 			t.Errorf("Output.%s never reaches Pairs, so no caller can ever write it", name)
 		}
 	}
@@ -378,9 +378,9 @@ func TestStripServerOnly(t *testing.T) {
 // This test turns that omission into a build failure instead of a silent leak.
 func TestServerOnlyKeysMatchDerivedOnlyFields(t *testing.T) {
 	inputFields := make(map[string]bool)
-	it := reflect.TypeOf(Input{})
-	for i := range it.NumField() {
-		inputFields[it.Field(i).Name] = true
+	it := reflect.TypeFor[Input]()
+	for field := range it.Fields() {
+		inputFields[field.Name] = true
 	}
 
 	// Output field name → its canonical Prop* key, via the Pairs table: stamp
@@ -397,8 +397,8 @@ func TestServerOnlyKeysMatchDerivedOnlyFields(t *testing.T) {
 	}
 
 	want := make(map[string]bool)
-	for i := range ot.NumField() {
-		name := ot.Field(i).Name
+	for field := range ot.Fields() {
+		name := field.Name
 		if inputFields[name] {
 			continue // client can supply it: derive-if-absent, not server-only
 		}

--- a/internal/cookieless/redis_integration_test.go
+++ b/internal/cookieless/redis_integration_test.go
@@ -425,9 +425,7 @@ func TestResolver_ConcurrentUse(t *testing.T) {
 	var wg sync.WaitGroup
 	ids := make([]string, goroutines)
 	for i := range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			// Alternate the day so both accepted-window entries are written and
 			// read concurrently, and the prune runs while others are reading.
 			day := Day("20260720")
@@ -441,7 +439,7 @@ func TestResolver_ConcurrentUse(t *testing.T) {
 			}
 			ids[i] = id
 			r.SessionID(ctx, "p1", id, day, now)
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/internal/core/auth/magic_link_test.go
+++ b/internal/core/auth/magic_link_test.go
@@ -409,13 +409,11 @@ func TestCompleteMagicLink_ConcurrentRedemptionSerializes(t *testing.T) {
 	start := make(chan struct{})
 	results := make([]error, n)
 	for i := range n {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 			_, err := svc.CompleteMagicLink(ctx, raw, "")
 			results[i] = err
-		}()
+		})
 	}
 	close(start) // release all goroutines together to maximize overlap
 	wg.Wait()

--- a/internal/core/auth/refresh_test.go
+++ b/internal/core/auth/refresh_test.go
@@ -101,12 +101,10 @@ func TestRefreshSession(t *testing.T) {
 		sessions := make([]auth.Session, n)
 		errs := make([]error, n)
 		for i := range n {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				<-start
 				sessions[i], errs[i] = svc.RefreshSession(ctx, session.RefreshToken)
-			}()
+			})
 		}
 		close(start) // release together to maximize overlap
 		wg.Wait()

--- a/internal/core/clickhouse/filters_validate_test.go
+++ b/internal/core/clickhouse/filters_validate_test.go
@@ -23,8 +23,7 @@ func opp(o commonv1.FilterOperator) *commonv1.FilterOperator { return &o }
 // — protovalidate wraps these as plain errors, not ValidationError, but the
 // failing rule id appears in the message text.
 func hasRule(err error, ruleSubstring string) bool {
-	var ve *protovalidate.ValidationError
-	if errors.As(err, &ve) {
+	if ve, ok := errors.AsType[*protovalidate.ValidationError](err); ok {
 		for _, v := range ve.Violations {
 			if strings.Contains(v.Proto.GetRuleId(), ruleSubstring) {
 				return true
@@ -352,7 +351,6 @@ func TestValidateProfilePropertyName_MirrorsProtoRegex(t *testing.T) {
 		"user-profile.first-name", "$session.duration", "a.b.c",
 	}
 	for _, name := range valid {
-		name := name
 		t.Run("valid_"+name, func(t *testing.T) {
 			if err := chq.ValidateProfilePropertyName(name); err != nil {
 				t.Errorf("expected valid, got %v", err)
@@ -365,7 +363,6 @@ func TestValidateProfilePropertyName_MirrorsProtoRegex(t *testing.T) {
 		"foo bar", "a/b", "a`b", "a;b", "a'b", "a\"b",
 	}
 	for _, name := range invalid {
-		name := name
 		t.Run("invalid_"+name, func(t *testing.T) {
 			if err := chq.ValidateProfilePropertyName(name); err == nil {
 				t.Errorf("expected error for %q, got nil", name)

--- a/internal/core/dashboards/query.go
+++ b/internal/core/dashboards/query.go
@@ -173,8 +173,7 @@ func renderInsightTile(
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, "", err // request lifecycle, not a tile fault — propagate
 		}
-		var invalid *coreinsights.InvalidQueryError
-		if errors.As(err, &invalid) {
+		if invalid, ok := errors.AsType[*coreinsights.InvalidQueryError](err); ok {
 			return nil, "invalid query parameters: " + invalid.Message, nil
 		}
 		return nil, "query failed", nil

--- a/internal/core/dashboards/shares_test.go
+++ b/internal/core/dashboards/shares_test.go
@@ -20,8 +20,8 @@ import (
 // dashboard_shares structs drift in field count — a forgotten field in
 // dbwriteShareToDbread compiles cleanly but silently zeroes a column.
 func TestDbwriteShareToDbread_FieldParity(t *testing.T) {
-	r := reflect.TypeOf(dbread.DashboardShare{}).NumField()
-	w := reflect.TypeOf(dbwrite.DashboardShare{}).NumField()
+	r := reflect.TypeFor[dbread.DashboardShare]().NumField()
+	w := reflect.TypeFor[dbwrite.DashboardShare]().NumField()
 	if r != w {
 		t.Fatalf("dbread.DashboardShare has %d fields, dbwrite has %d — keep dbwriteShareToDbread in sync", r, w)
 	}

--- a/internal/core/events/events_validate_test.go
+++ b/internal/core/events/events_validate_test.go
@@ -19,8 +19,7 @@ import (
 // coercion), which protovalidate wraps as plain errors but include the rule id
 // in the message text.
 func hasRule(err error, ruleSubstring string) bool {
-	var ve *protovalidate.ValidationError
-	if errors.As(err, &ve) {
+	if ve, ok := errors.AsType[*protovalidate.ValidationError](err); ok {
 		for _, v := range ve.Violations {
 			if strings.Contains(v.Proto.GetRuleId(), ruleSubstring) {
 				return true

--- a/internal/core/events/reader_test.go
+++ b/internal/core/events/reader_test.go
@@ -1751,7 +1751,7 @@ func TestGetProfileStats(t *testing.T) {
 	)
 
 	// Day 0: 2 events with latest props.
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		testutil.InsertEvent(ctx, t, ch.Conn, uuid.NewString(), "proj-1", "user-1", "page_view", uuid.NewString(),
 			latestProps,
 			map[string]string{},

--- a/internal/core/insights/identity_resolution_test.go
+++ b/internal/core/insights/identity_resolution_test.go
@@ -159,11 +159,8 @@ func TestIdentityResolution(t *testing.T) {
 		finalStep := int64(len(req.GetSpec().GetEvents()) - 1)
 		reachedFinal := 0
 		for _, u := range users {
-			for _, m := range u.StepMatches {
-				if m == finalStep {
-					reachedFinal++
-					break
-				}
+			if slices.Contains(u.StepMatches, finalStep) {
+				reachedFinal++
 			}
 		}
 		if reachedFinal != 2 {

--- a/internal/core/insights/integration_test.go
+++ b/internal/core/insights/integration_test.go
@@ -1444,7 +1444,7 @@ func TestIntegration(t *testing.T) {
 		// Insert the same event twice (identical dedup key): an at-least-once
 		// redelivery / client retry. Raw collapses these on merge; the incremental
 		// MV fires per insert and sums them.
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			if err := insertAutoEvent(ctx, ch.Conn, dupProjectID, eventID, "page_view", "alice", occur,
 				variantStringMap(map[string]string{"$country": "US"})); err != nil {
 				t.Fatalf("seed dup event %d: %v", i, err)
@@ -1632,7 +1632,7 @@ func TestIntegration(t *testing.T) {
 		sessionID := "00000000-0000-0000-0000-0000000000e5"
 		eventID := uuid.New().String()
 		// Same event_id twice = an at-least-once redelivery of a one-event session.
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			if err := insertSessionEvent(ctx, ch.Conn, dupProjectID, eventID,
 				"page_view", "alice", sessionID, occur, "/only", "US"); err != nil {
 				t.Fatalf("seed dup session event %d: %v", i, err)

--- a/internal/core/insights/query_execute_test.go
+++ b/internal/core/insights/query_execute_test.go
@@ -19,8 +19,7 @@ func TestExecuteQuery_RejectsUnloadableTimezone(t *testing.T) {
 		Timezone: proto.String("Not/A/Zone"),
 	}
 	_, err := ExecuteQuery(context.Background(), &Executor{}, "proj_123", req, time.Now())
-	var invalid *InvalidQueryError
-	if !errors.As(err, &invalid) {
+	if _, ok := errors.AsType[*InvalidQueryError](err); !ok {
 		t.Fatalf("err = %v (%T), want *InvalidQueryError", err, err)
 	}
 }

--- a/internal/core/insights/rollup_test.go
+++ b/internal/core/insights/rollup_test.go
@@ -87,11 +87,11 @@ func cteBody(t *testing.T, sql, name string) string {
 		t.Fatalf("CTE %s not found in:\n%s", name, sql)
 	}
 	rest := sql[i+len(open):]
-	j := strings.Index(rest, "\n)")
-	if j < 0 {
+	before, _, ok := strings.Cut(rest, "\n)")
+	if !ok {
 		t.Fatalf("unterminated CTE %s in:\n%s", name, sql)
 	}
-	return rest[:j]
+	return before
 }
 
 // TestBuildTrendsFromRollup_TopValsMirrorsApplyTrendsTopN pins the three axes on

--- a/internal/core/insights/session_test.go
+++ b/internal/core/insights/session_test.go
@@ -317,7 +317,7 @@ func TestMigration010SessionRollupColumnsMatchDims(t *testing.T) {
 		t.Fatal("migration 010 Up missing the partial backfill INSERT column list")
 	}
 	var cols []string
-	for _, c := range strings.Split(m[1], ",") {
+	for c := range strings.SplitSeq(m[1], ",") {
 		cols = append(cols, strings.TrimSpace(c))
 	}
 	want := []string{"project_id", "kind", "session_id"}

--- a/internal/core/insights/topk_test.go
+++ b/internal/core/insights/topk_test.go
@@ -1,6 +1,7 @@
 package insights_test
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -333,13 +334,7 @@ func TestBuildTopKQuery_ScopeAndFiltersInBothScans(t *testing.T) {
 		}
 	}
 	for _, v := range []any{"page_view", "US", "pro"} {
-		found := false
-		for _, a := range cteArgs {
-			if a == v {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(cteArgs, v)
 		if !found {
 			t.Errorf("expected arg %v in scan args, got: %v", v, cteArgs)
 		}

--- a/internal/core/orgs/service_test.go
+++ b/internal/core/orgs/service_test.go
@@ -504,7 +504,7 @@ func TestResendInviteEnforcesSendLimit(t *testing.T) {
 
 	// The invitation was already sent once, so the window allows
 	// maxInviteSendsPerWindow-1 resends before it trips.
-	for i := 0; i < 9; i++ {
+	for i := range 9 {
 		if _, err := f.svc.ResendInvite(ctx, f.org.ID, f.invite.ID); err != nil {
 			t.Fatalf("ResendInvite %d: %v", i, err)
 		}
@@ -525,7 +525,7 @@ func TestResendInviteSendLimitClearsAfterWindow(t *testing.T) {
 	f := newInviteFixture(t, "recovers@example.com")
 	ctx := context.Background()
 
-	for i := 0; i < 9; i++ {
+	for i := range 9 {
 		if _, err := f.svc.ResendInvite(ctx, f.org.ID, f.invite.ID); err != nil {
 			t.Fatalf("ResendInvite %d: %v", i, err)
 		}
@@ -1275,7 +1275,7 @@ func TestLeaveTwoAdminsRaceExactlyOneSucceeds(t *testing.T) {
 	// silently allowed both goroutines through could pass a single trial by
 	// coincidence of scheduling. Five iterations make that hard.
 	const iterations = 5
-	for i := 0; i < iterations; i++ {
+	for i := range iterations {
 		a := seedCustomer(t, ctx, write, "racer-a")
 		b := seedCustomer(t, ctx, write, "racer-b")
 		org, err := svc.CreateOrgWithDefaults(ctx, a, "race-org")

--- a/internal/core/profiles/erasure.go
+++ b/internal/core/profiles/erasure.go
@@ -1102,10 +1102,7 @@ const chBatchSize = 1000
 // chunk, stopping at the first error. An empty slice invokes fn zero times.
 func forEachBatch(values []string, fn func(batch []string) error) error {
 	for start := 0; start < len(values); start += chBatchSize {
-		end := start + chBatchSize
-		if end > len(values) {
-			end = len(values)
-		}
+		end := min(start+chBatchSize, len(values))
 		if err := fn(values[start:end]); err != nil {
 			return err
 		}

--- a/internal/core/projects/key_test.go
+++ b/internal/core/projects/key_test.go
@@ -46,7 +46,7 @@ func TestKeyUniqueness(t *testing.T) {
 	const n = 100
 	seen := make(map[string]struct{}, n*2)
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		prv, err := newPrivateKey()
 		if err != nil {
 			t.Fatalf("newPrivateKey iteration %d: %v", i, err)

--- a/internal/deps/email/smtp/smtp_test.go
+++ b/internal/deps/email/smtp/smtp_test.go
@@ -37,9 +37,11 @@ type fakeSMTPServer struct {
 // them after newFakeSMTPServer returns would race the goroutine.
 type fakeOption func(*fakeSMTPServer)
 
-func withDropOnQuit() fakeOption        { return func(s *fakeSMTPServer) { s.dropOnQuit = true } }
-func withHangAfterGreeting() fakeOption { return func(s *fakeSMTPServer) { s.hangAfterGreeting = true } }
-func withSilentOnAccept() fakeOption    { return func(s *fakeSMTPServer) { s.silentOnAccept = true } }
+func withDropOnQuit() fakeOption { return func(s *fakeSMTPServer) { s.dropOnQuit = true } }
+func withHangAfterGreeting() fakeOption {
+	return func(s *fakeSMTPServer) { s.hangAfterGreeting = true }
+}
+func withSilentOnAccept() fakeOption { return func(s *fakeSMTPServer) { s.silentOnAccept = true } }
 
 func newFakeSMTPServer(t *testing.T, opts ...fakeOption) *fakeSMTPServer {
 	t.Helper()
@@ -213,7 +215,7 @@ func TestSMTPProviderSanitizesHeaders(t *testing.T) {
 	// The dangerous outcome is a standalone Bcc: header line. The CRLF must
 	// have been stripped so the malicious payload is collapsed into the
 	// Subject value (where it's harmless content, not a header).
-	for _, line := range strings.Split(body, "\r\n") {
+	for line := range strings.SplitSeq(body, "\r\n") {
 		if strings.HasPrefix(line, "Bcc:") {
 			t.Fatalf("Bcc header injected on its own line: %q", line)
 		}

--- a/internal/deps/telemetry/otel.go
+++ b/internal/deps/telemetry/otel.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"os"
+	"slices"
 	"sync"
 	"time"
 
@@ -60,8 +61,8 @@ func doSetupSDK(ctx context.Context) (func(context.Context) error, error) {
 	success := false
 	defer func() {
 		if !success {
-			for i := len(shutdowns) - 1; i >= 0; i-- {
-				if err := shutdowns[i](ctx); err != nil {
+			for _, shutdown := range slices.Backward(shutdowns) {
+				if err := shutdown(ctx); err != nil {
 					slog.ErrorContext(ctx, "cleanup error during init rollback", slogx.Error(err))
 				}
 			}

--- a/internal/testutil/shared.go
+++ b/internal/testutil/shared.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -146,8 +147,8 @@ func (r *teardownRegistry) run() error {
 		if len(fns) == 0 {
 			break
 		}
-		for i := len(fns) - 1; i >= 0; i-- {
-			errs = append(errs, runTeardown(fns[i]))
+		for _, fn := range slices.Backward(fns) {
+			errs = append(errs, runTeardown(fn))
 		}
 	}
 	return errors.Join(errs...)


### PR DESCRIPTION
Disable newexpr: it would rewrite ~1350 proto.String/Bool call sites and new(x) loses the idiom that marks an optional field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal Go code using newer standard-library APIs and language features.
  * Simplified iteration, reflection, error handling, collection operations, string parsing, and batch processing.
  * Preserved existing rollback, cleanup, validation, and error-handling behavior.

* **Tests**
  * Updated test utilities and concurrent test setup for clearer, more maintainable code.
  * Existing test coverage and assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->