### PR TITLE
ci(coderabbit): gate reviews behind an org-member label

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+reviews:
+  auto_review:
+    # Deny by default: CodeRabbit sees the `opened` webhook before any workflow can run, so a
+    # missing label is the only gate that can win the race. coderabbit-gate.yaml grants it.
+    enabled: false
+    labels:
+      - coderabbit

--- a/.github/workflows/coderabbit-gate.yaml
+++ b/.github/workflows/coderabbit-gate.yaml
@@ -1,0 +1,31 @@
+name: CodeRabbit gate
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  label:
+    # No COLLABORATOR: an org member reads as MEMBER, so that value only ever means an outside
+    # collaborator. dependabot reads as `CONTRIBUTOR`, so it needs the login check; its branches are ours.
+    if: >-
+      github.event.pull_request.draft == false
+      && (contains(fromJSON('["OWNER", "MEMBER"]'),
+      github.event.pull_request.author_association)
+      || github.event.pull_request.user.login == 'dependabot[bot]')
+    runs-on: ubuntu-latest
+    steps:
+      # pull_request_target, since a fork PR's token is read-only. Nothing is checked out, so no PR
+      # code runs against this one.
+      - name: Opt the PR into review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh label create coderabbit --repo "$GITHUB_REPOSITORY" --color BFD4F2 \
+            --description "CodeRabbit reviews this PR" --force
+          gh pr edit "$PR" --repo "$GITHUB_REPOSITORY" --add-label coderabbit


### PR DESCRIPTION
CodeRabbit reviewed every PR, so anyone outside the org could spend review credits. Deny by default beats a blocking label — the `opened` webhook lands before any workflow can — and the gate labels org members plus dependabot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated configuration to control when pull requests receive CodeRabbit reviews.
  * Eligible, non-draft pull requests can now be labeled automatically to trigger review workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->