### PR TITLE
ci(cla): report the verdict in a comment and a label

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -17,7 +17,9 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  # write, so the gate can tell the contributor what to do in a comment rather
+  # than only in a log they have to go looking for.
+  pull-requests: write
 
 concurrency:
   group: cla-${{ github.event.pull_request.number }}

--- a/tools/clacheck/github.go
+++ b/tools/clacheck/github.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -98,16 +99,26 @@ var nextPageRe = regexp.MustCompile(`<([^>]+)>;\s*rel="next"`)
 // simply stops sending a next link, so the caller compares the count against the
 // pull request's own commit total rather than trusting the walk to be complete.
 func (c *client) pullCommits(ctx context.Context, pr int) ([]Commit, error) {
-	endpoint := fmt.Sprintf("%s/repos/%s/pulls/%d/commits?per_page=100", c.baseURL, c.repo, pr)
-	var all []Commit
+	all, err := listPaged[Commit](ctx, c, fmt.Sprintf("%s/repos/%s/pulls/%d/commits?per_page=100", c.baseURL, c.repo, pr), "commit")
+	if err != nil {
+		return nil, err
+	}
+	slog.DebugContext(ctx, "listed commits", slog.Int("pr", pr), slog.Int("commits", len(all)))
+	return all, nil
+}
+
+// listPaged follows the Link header, so a short read is detectable rather than
+// read as a complete list.
+func listPaged[T any](ctx context.Context, c *client, endpoint, what string) ([]T, error) {
+	var all []T
 	for endpoint != "" {
 		body, header, err := c.get(ctx, endpoint, "application/vnd.github+json")
 		if err != nil {
 			return nil, err
 		}
-		var page []Commit
+		var page []T
 		if err := json.Unmarshal(body, &page); err != nil {
-			slog.ErrorContext(ctx, "a commit page did not decode", slog.String("endpoint", endpoint), errAttr(err))
+			slog.ErrorContext(ctx, "a "+what+" page did not decode", slog.String("endpoint", endpoint), errAttr(err))
 			return nil, err
 		}
 		all = append(all, page...)
@@ -116,7 +127,6 @@ func (c *client) pullCommits(ctx context.Context, pr int) ([]Commit, error) {
 			endpoint = m[1]
 		}
 	}
-	slog.DebugContext(ctx, "listed commits", slog.Int("pr", pr), slog.Int("commits", len(all)))
 	return all, nil
 }
 
@@ -177,4 +187,89 @@ func (c *client) userByEmail(ctx context.Context, email string) (Principal, erro
 		return Principal{}, errNotFound
 	}
 	return res.Items[0], nil
+}
+
+// Comment is the gate's own pull request comment, matched by its marker rather
+// than by author: the token's identity differs between a GitHub App and Actions.
+type Comment struct {
+	ID   int64  `json:"id"`
+	Body string `json:"body"`
+}
+
+// GitHub answers a create with 201 and an edit with 200, so any 2xx counts.
+func (c *client) send(ctx context.Context, method, endpoint string, payload any) error {
+	var body io.Reader
+	if payload != nil {
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		slog.ErrorContext(ctx, "github request failed", slog.String("endpoint", endpoint), errAttr(err))
+		return err
+	}
+	defer resp.Body.Close()
+	res, err := io.ReadAll(resp.Body)
+	if err != nil {
+		slog.ErrorContext(ctx, "reading the github response failed", slog.String("endpoint", endpoint), errAttr(err))
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		err := fmt.Errorf("%s %s: %s: %s", method, endpoint, resp.Status, strings.TrimSpace(string(res)))
+		// The rate limit separates a throttled 403 from a permissions 403, which
+		// look identical here and have opposite remedies.
+		slog.ErrorContext(ctx, "github returned an unexpected status",
+			slog.String("endpoint", endpoint), slog.Int("status", resp.StatusCode),
+			slog.String("rate_limit_remaining", resp.Header.Get("X-RateLimit-Remaining")), errAttr(err))
+		return err
+	}
+	return nil
+}
+
+func (c *client) comments(ctx context.Context, pr int) ([]Comment, error) {
+	return listPaged[Comment](ctx, c, fmt.Sprintf("%s/repos/%s/issues/%d/comments?per_page=100", c.baseURL, c.repo, pr), "comment")
+}
+
+func (c *client) createComment(ctx context.Context, pr int, body string) error {
+	endpoint := fmt.Sprintf("%s/repos/%s/issues/%d/comments", c.baseURL, c.repo, pr)
+	return c.send(ctx, http.MethodPost, endpoint, map[string]string{"body": body})
+}
+
+func (c *client) updateComment(ctx context.Context, id int64, body string) error {
+	endpoint := fmt.Sprintf("%s/repos/%s/issues/comments/%d", c.baseURL, c.repo, id)
+	return c.send(ctx, http.MethodPatch, endpoint, map[string]string{"body": body})
+}
+
+type Label struct {
+	Name string `json:"name"`
+}
+
+func (c *client) labels(ctx context.Context, pr int) ([]Label, error) {
+	return listPaged[Label](ctx, c, fmt.Sprintf("%s/repos/%s/issues/%d/labels?per_page=100", c.baseURL, c.repo, pr), "label")
+}
+
+func (c *client) addLabel(ctx context.Context, pr int, name string) error {
+	endpoint := fmt.Sprintf("%s/repos/%s/issues/%d/labels", c.baseURL, c.repo, pr)
+	return c.send(ctx, http.MethodPost, endpoint, map[string][]string{"labels": {name}})
+}
+
+// The name is escaped, not interpolated: it carries a space and a colon.
+func (c *client) removeLabel(ctx context.Context, pr int, name string) error {
+	endpoint := fmt.Sprintf("%s/repos/%s/issues/%d/labels/%s", c.baseURL, c.repo, pr, url.PathEscape(name))
+	return c.send(ctx, http.MethodDelete, endpoint, nil)
 }

--- a/tools/clacheck/github_test.go
+++ b/tools/clacheck/github_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -106,5 +107,110 @@ func TestMergeBaseRefusesAnEmptyResult(t *testing.T) {
 	})
 	if _, err := c.mergeBase(t.Context(), "base", "head"); err == nil {
 		t.Fatal("want an error when no merge base comes back")
+	}
+}
+
+// The comment endpoints are the gate's only writes; a wrong method or path is
+// silent at compile time and only shows up as a comment nobody ever receives.
+func TestCommentWritesUseTheIssueEndpoints(t *testing.T) {
+	var method, path, body string
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		method, path = r.Method, r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		body = string(b)
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"id":1}`)
+	})
+
+	if err := c.createComment(t.Context(), 7, "please sign"); err != nil {
+		t.Fatalf("createComment: %v", err)
+	}
+	if method != http.MethodPost || path != "/repos/pug-sh/pug/issues/7/comments" {
+		t.Fatalf("want a POST to the pull request's comments, got %s %s", method, path)
+	}
+	if !strings.Contains(body, `"body":"please sign"`) {
+		t.Fatalf("want the comment body in the payload, got %s", body)
+	}
+
+	if err := c.updateComment(t.Context(), 42, "signed"); err != nil {
+		t.Fatalf("updateComment: %v", err)
+	}
+	if method != http.MethodPatch || path != "/repos/pug-sh/pug/issues/comments/42" {
+		t.Fatalf("want a PATCH to the comment itself, got %s %s", method, path)
+	}
+}
+
+// Stopping at page one would hide the gate's own comment on a busy pull request,
+// so every push would post another one instead of editing it.
+func TestCommentsWalksEveryPage(t *testing.T) {
+	var base string
+	page := 0
+	c := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		page++
+		if page == 1 {
+			w.Header().Set("Link", fmt.Sprintf(`<%s/page2>; rel="next"`, base))
+			fmt.Fprint(w, `[{"id":1,"body":"first"}]`)
+			return
+		}
+		fmt.Fprint(w, `[{"id":2,"body":"second"}]`)
+	})
+	base = c.baseURL
+
+	all, err := c.comments(t.Context(), 7)
+	if err != nil {
+		t.Fatalf("comments: %v", err)
+	}
+	if len(all) != 2 || all[0].ID != 1 || all[1].ID != 2 {
+		t.Fatalf("want both pages, got %+v", all)
+	}
+}
+
+func TestSendSurfacesARefusedWrite(t *testing.T) {
+	c := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, "resource not accessible by integration")
+	})
+	err := c.createComment(t.Context(), 7, "please sign")
+	if err == nil || !strings.Contains(err.Error(), "resource not accessible") {
+		t.Fatalf("want the refusal surfaced, got %v", err)
+	}
+}
+
+// The label name carries a space and a colon, so removing it goes through a
+// path-escaped URL rather than a formatted one.
+func TestLabelWritesUseTheIssueEndpoints(t *testing.T) {
+	var method, path, body string
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		method, path = r.Method, r.URL.EscapedPath()
+		b, _ := io.ReadAll(r.Body)
+		body = string(b)
+		fmt.Fprint(w, `[]`)
+	})
+
+	if _, err := c.labels(t.Context(), 7); err != nil {
+		t.Fatalf("labels: %v", err)
+	}
+	if method != http.MethodGet || path != "/repos/pug-sh/pug/issues/7/labels" {
+		t.Fatalf("want a GET of the pull request's labels, got %s %s", method, path)
+	}
+
+	if err := c.addLabel(t.Context(), 7, labelUnsigned); err != nil {
+		t.Fatalf("addLabel: %v", err)
+	}
+	if method != http.MethodPost || path != "/repos/pug-sh/pug/issues/7/labels" {
+		t.Fatalf("want a POST to the pull request's labels, got %s %s", method, path)
+	}
+	if !strings.Contains(body, `{"labels":["cla: not signed"]}`) {
+		t.Fatalf("want the label in the payload, got %s", body)
+	}
+
+	if err := c.removeLabel(t.Context(), 7, labelUnsigned); err != nil {
+		t.Fatalf("removeLabel: %v", err)
+	}
+	if method != http.MethodDelete || path != "/repos/pug-sh/pug/issues/7/labels/cla:%20not%20signed" {
+		t.Fatalf("want an escaped DELETE to the label itself, got %s %s", method, path)
+	}
+	if body != "" {
+		t.Fatalf("a delete must not carry a body, got %q", body)
 	}
 }

--- a/tools/clacheck/main.go
+++ b/tools/clacheck/main.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -100,6 +101,12 @@ type githubAPI interface {
 	mergeBase(ctx context.Context, base, head string) (string, error)
 	userByLogin(ctx context.Context, login string) (Principal, error)
 	userByEmail(ctx context.Context, email string) (Principal, error)
+	comments(ctx context.Context, pr int) ([]Comment, error)
+	createComment(ctx context.Context, pr int, body string) error
+	updateComment(ctx context.Context, id int64, body string) error
+	labels(ctx context.Context, pr int) ([]Label, error)
+	addLabel(ctx context.Context, pr int, name string) error
+	removeLabel(ctx context.Context, pr int, name string) error
 }
 
 // checker is everything the gate talks to. run assembles it once so check itself
@@ -144,7 +151,18 @@ func run(ctx context.Context) error {
 	return c.check(ctx)
 }
 
+// A gate that fell over must not leave "signed — thanks!" standing on a red
+// check, nor advice the contributor has just followed and failed on.
 func (c *checker) check(ctx context.Context) error {
+	err := c.verdict(ctx)
+	if err != nil && !errors.Is(err, errUnsigned) {
+		c.upsertComment(ctx, problemComment(), false)
+		c.syncLabels(ctx, "", labelSigned)
+	}
+	return err
+}
+
+func (c *checker) verdict(ctx context.Context) error {
 	slog.InfoContext(ctx, "checking signatures",
 		slog.String("repo", c.cfg.repo), slog.Int("pr", c.cfg.pr), slog.String("head", c.cfg.headSHA))
 
@@ -196,15 +214,19 @@ func (c *checker) check(ctx context.Context) error {
 
 	missing, checked := unsigned(head, people)
 	if len(missing) > 0 {
-		report := unsignedReport(c.cfg, head.CLAVersion, missing, c.now())
+		report := unsignedReport(c.cfg, head, missing, c.now())
 		fmt.Fprint(c.out, report.text)
 		c.writeSummary(ctx, report.markdown)
+		c.upsertComment(ctx, report.comment, true)
+		c.syncLabels(ctx, labelUnsigned, labelSigned)
 		return errUnsigned
 	}
 	// A pull request authored entirely by bots — dependabot and friends — has no
 	// human copyright to license, so there is nothing to sign for.
 	if len(checked) == 0 {
 		fmt.Fprintf(c.out, "CLA %s: no human authors across %d commit(s); nothing to sign\n", head.CLAVersion, len(commits))
+		c.upsertComment(ctx, signedComment(head.CLAVersion), false)
+		c.syncLabels(ctx, labelSigned, labelUnsigned)
 		return nil
 	}
 
@@ -214,7 +236,70 @@ func (c *checker) check(ctx context.Context) error {
 	}
 	fmt.Fprintf(c.out, "CLA %s verified for %d principal(s) across %d commit(s): %s\n",
 		head.CLAVersion, len(checked), len(commits), strings.Join(logins, ", "))
+	c.upsertComment(ctx, signedComment(head.CLAVersion), false)
+	c.syncLabels(ctx, labelSigned, labelUnsigned)
 	return nil
+}
+
+// syncLabels reads first so a run that changes nothing writes nothing: a label
+// event fires every subscriber on the pull request. Best-effort, like the comment.
+func (c *checker) syncLabels(ctx context.Context, add, remove string) {
+	current, err := c.gh.labels(ctx, c.cfg.pr)
+	if err != nil {
+		c.writeFailed(ctx, "could not list the pull request labels", err)
+		return
+	}
+	has := func(name string) bool {
+		return slices.ContainsFunc(current, func(l Label) bool { return l.Name == name })
+	}
+	if remove != "" && has(remove) {
+		if err := c.gh.removeLabel(ctx, c.cfg.pr, remove); err != nil {
+			c.writeFailed(ctx, "could not remove the stale cla label", err)
+		}
+	}
+	if add != "" && !has(add) {
+		if err := c.gh.addLabel(ctx, c.cfg.pr, add); err != nil {
+			c.writeFailed(ctx, "could not add the cla label", err)
+		}
+	}
+}
+
+// upsertComment edits the marked comment in place, so a contributor pushing five
+// times is notified once. Best-effort: failing the gate because a comment did not
+// post would block a pull request that is signed.
+func (c *checker) upsertComment(ctx context.Context, body string, create bool) {
+	existing, err := c.gh.comments(ctx, c.cfg.pr)
+	if err != nil {
+		c.writeFailed(ctx, "could not list the pull request comments", err)
+		return
+	}
+	for _, cm := range existing {
+		// Prefix, not contains: quote-reply copies the marker into the quoting
+		// user's comment, and the token cannot edit that one anyway.
+		if !strings.HasPrefix(cm.Body, commentMarker) {
+			continue
+		}
+		if cm.Body == body {
+			return
+		}
+		if err := c.gh.updateComment(ctx, cm.ID, body); err != nil {
+			c.writeFailed(ctx, "could not update the signature comment", err)
+		}
+		return
+	}
+	if !create {
+		return
+	}
+	if err := c.gh.createComment(ctx, c.cfg.pr, body); err != nil {
+		c.writeFailed(ctx, "could not post the signature comment", err)
+	}
+}
+
+// Annotates too: the signed run that most needs this seen exits 0, and nobody
+// opens a green job's log.
+func (c *checker) writeFailed(ctx context.Context, msg string, err error) {
+	slog.ErrorContext(ctx, msg, slog.String("repo", c.cfg.repo), slog.Int("pr", c.cfg.pr), errAttr(err))
+	fmt.Fprintf(c.out, "::warning::%s\n", escapeAnnotation(msg))
 }
 
 // baseFile reads the signature file as it stands at the merge base. The event's

--- a/tools/clacheck/main_test.go
+++ b/tools/clacheck/main_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -21,6 +22,14 @@ type fakeGitHub struct {
 	byEmail   map[string]Principal
 	lookupErr error
 	base      string // ref check should read the base file at; defaults to "base"
+
+	posted   []Comment
+	edits    int
+	listErr  error
+	writeErr error
+
+	labelled    []string
+	labelWrites int
 }
 
 func (f *fakeGitHub) signatureFile(_ context.Context, ref string) (*SignatureFile, error) {
@@ -57,6 +66,58 @@ func (f *fakeGitHub) userByEmail(_ context.Context, email string) (Principal, er
 		return p, nil
 	}
 	return Principal{}, errNotFound
+}
+
+func (f *fakeGitHub) comments(context.Context, int) ([]Comment, error) {
+	return f.posted, f.listErr
+}
+
+func (f *fakeGitHub) createComment(_ context.Context, _ int, body string) error {
+	if f.writeErr != nil {
+		return f.writeErr
+	}
+	f.posted = append(f.posted, Comment{ID: int64(len(f.posted) + 1), Body: body})
+	return nil
+}
+
+func (f *fakeGitHub) updateComment(_ context.Context, id int64, body string) error {
+	if f.writeErr != nil {
+		return f.writeErr
+	}
+	for i := range f.posted {
+		if f.posted[i].ID == id {
+			f.posted[i].Body = body
+			f.edits++
+			return nil
+		}
+	}
+	return errNotFound
+}
+
+func (f *fakeGitHub) labels(context.Context, int) ([]Label, error) {
+	out := make([]Label, len(f.labelled))
+	for i, n := range f.labelled {
+		out[i] = Label{Name: n}
+	}
+	return out, f.listErr
+}
+
+func (f *fakeGitHub) addLabel(_ context.Context, _ int, name string) error {
+	if f.writeErr != nil {
+		return f.writeErr
+	}
+	f.labelWrites++
+	f.labelled = append(f.labelled, name)
+	return nil
+}
+
+func (f *fakeGitHub) removeLabel(_ context.Context, _ int, name string) error {
+	if f.writeErr != nil {
+		return f.writeErr
+	}
+	f.labelWrites++
+	f.labelled = slices.DeleteFunc(f.labelled, func(n string) bool { return n == name })
+	return nil
 }
 
 var fixedNow = time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
@@ -289,10 +350,12 @@ func TestUnresolvableCoauthorIsReported(t *testing.T) {
 func TestAllBotPullRequestPasses(t *testing.T) {
 	var out bytes.Buffer
 	bot := &Principal{ID: 49699333, Login: "dependabot[bot]", Type: "Bot"}
-	c := newChecker(&fakeGitHub{
+	gh := &fakeGitHub{
 		files:   map[string]*SignatureFile{"head": file(), "base": file()},
 		commits: []Commit{commit("a1", bot, bot, "chore(deps): bump x")},
-	}, &out)
+		posted:  []Comment{{ID: 9, Body: commentMarker + "\n## Signature required"}},
+	}
+	c := newChecker(gh, &out)
 	c.cfg.opener = *bot
 
 	if err := c.check(t.Context()); err != nil {
@@ -300,6 +363,10 @@ func TestAllBotPullRequestPasses(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "nothing to sign") {
 		t.Fatalf("want the bot-only line, got %q", out.String())
+	}
+	// Rebasing a human commit away leaves nobody to demand a signature from.
+	if gh.edits != 1 || strings.Contains(gh.posted[0].Body, "Signature required") {
+		t.Fatalf("want the standing demand resolved, got %q", gh.posted[0].Body)
 	}
 }
 
@@ -358,5 +425,244 @@ func TestEscapeAnnotationEncodesTheSpecialCharacters(t *testing.T) {
 	got := escapeAnnotation("100% done\r\nnext")
 	if got != "100%25 done%0D%0Anext" {
 		t.Fatalf("got %q", got)
+	}
+}
+
+// An unsigned run must reach the contributor somewhere other than a job log, and
+// must name them in a form GitHub notifies on.
+func TestCheckCommentsMentioningTheUnsignedContributor(t *testing.T) {
+	gh := &fakeGitHub{
+		files:   map[string]*SignatureFile{"head": file(), "base": file()},
+		commits: []Commit{commit("a1", user("alice", 1), user("alice", 1), "x")},
+	}
+	c := newChecker(gh, &bytes.Buffer{})
+
+	if err := c.check(t.Context()); !errors.Is(err, errUnsigned) {
+		t.Fatalf("want errUnsigned, got %v", err)
+	}
+	if len(gh.posted) != 1 {
+		t.Fatalf("want one comment, got %d", len(gh.posted))
+	}
+	for _, want := range []string{commentMarker, "@alice", `"id": 1`} {
+		if !strings.Contains(gh.posted[0].Body, want) {
+			t.Fatalf("want %q in the comment, got %q", want, gh.posted[0].Body)
+		}
+	}
+}
+
+// A contributor pushing repeatedly must be notified once. The marked comment is
+// edited in place; a second one would be a new notification every push.
+func TestCheckEditsItsOwnCommentInsteadOfPostingAnother(t *testing.T) {
+	gh := &fakeGitHub{
+		files:   map[string]*SignatureFile{"head": file(), "base": file()},
+		commits: []Commit{commit("a1", user("bob", 2), user("bob", 2), "x")},
+		posted:  []Comment{{ID: 5, Body: "someone else's review"}, {ID: 9, Body: commentMarker + "\nstale"}},
+	}
+	c := newChecker(gh, &bytes.Buffer{})
+
+	if err := c.check(t.Context()); !errors.Is(err, errUnsigned) {
+		t.Fatalf("want errUnsigned, got %v", err)
+	}
+	if len(gh.posted) != 2 || gh.edits != 1 {
+		t.Fatalf("want the marked comment edited and none added, got %d comments and %d edits", len(gh.posted), gh.edits)
+	}
+	if !strings.Contains(gh.posted[1].Body, "bob") || strings.Contains(gh.posted[1].Body, "stale") {
+		t.Fatalf("want the marked comment replaced, got %q", gh.posted[1].Body)
+	}
+}
+
+// An unchanged report must not be rewritten: an edit bumps the comment's
+// timestamp and reads as news to everyone watching the pull request.
+func TestCheckLeavesAnUnchangedCommentAlone(t *testing.T) {
+	gh := &fakeGitHub{
+		files:   map[string]*SignatureFile{"head": file(), "base": file()},
+		commits: []Commit{commit("a1", user("bob", 2), user("bob", 2), "x")},
+	}
+	c := newChecker(gh, &bytes.Buffer{})
+	if err := c.check(t.Context()); !errors.Is(err, errUnsigned) {
+		t.Fatalf("want errUnsigned, got %v", err)
+	}
+	if err := c.check(t.Context()); !errors.Is(err, errUnsigned) {
+		t.Fatalf("want errUnsigned on the re-run, got %v", err)
+	}
+	if len(gh.posted) != 1 || gh.edits != 0 {
+		t.Fatalf("want the same comment untouched, got %d comments and %d edits", len(gh.posted), gh.edits)
+	}
+}
+
+// Once signed, the demand has been met: the comment is replaced rather than left
+// standing on a merged pull request. A pull request that was never asked gets no
+// comment at all.
+func TestCheckResolvesItsCommentOnceSigned(t *testing.T) {
+	gh := &fakeGitHub{
+		files:   map[string]*SignatureFile{"head": file(sig("alice", 1)), "base": file(sig("alice", 1))},
+		commits: []Commit{commit("a1", user("alice", 1), user("alice", 1), "x")},
+		posted:  []Comment{{ID: 9, Body: commentMarker + "\n## Signature required"}},
+	}
+	c := newChecker(gh, &bytes.Buffer{})
+
+	if err := c.check(t.Context()); err != nil {
+		t.Fatalf("want a pass, got %v", err)
+	}
+	if len(gh.posted) != 1 || !strings.Contains(gh.posted[0].Body, "CLA v1 signed") {
+		t.Fatalf("want the request replaced by the signed note, got %+v", gh.posted)
+	}
+
+	quiet := &fakeGitHub{
+		files:   map[string]*SignatureFile{"head": file(sig("alice", 1)), "base": file(sig("alice", 1))},
+		commits: []Commit{commit("a1", user("alice", 1), user("alice", 1), "x")},
+	}
+	if err := newChecker(quiet, &bytes.Buffer{}).check(t.Context()); err != nil {
+		t.Fatalf("want a pass, got %v", err)
+	}
+	if len(quiet.posted) != 0 {
+		t.Fatalf("a signed pull request must not be commented on, got %+v", quiet.posted)
+	}
+}
+
+// The comment is best-effort: a repository whose token cannot comment must still
+// fail on the signature, not on the notification.
+func TestCheckKeepsItsVerdictWhenCommentingFails(t *testing.T) {
+	gh := &fakeGitHub{
+		files:    map[string]*SignatureFile{"head": file(), "base": file()},
+		commits:  []Commit{commit("a1", user("bob", 2), user("bob", 2), "x")},
+		writeErr: errors.New("403 resource not accessible by integration"),
+	}
+	if err := newChecker(gh, &bytes.Buffer{}).check(t.Context()); !errors.Is(err, errUnsigned) {
+		t.Fatalf("want errUnsigned, got %v", err)
+	}
+
+	signed := &fakeGitHub{
+		files:   map[string]*SignatureFile{"head": file(sig("alice", 1)), "base": file(sig("alice", 1))},
+		commits: []Commit{commit("a1", user("alice", 1), user("alice", 1), "x")},
+		posted:  []Comment{{ID: 9, Body: commentMarker + "\n## Signature required"}},
+		listErr: errors.New("403 resource not accessible by integration"),
+	}
+	if err := newChecker(signed, &bytes.Buffer{}).check(t.Context()); err != nil {
+		t.Fatalf("a failed comment must not fail a signed pull request, got %v", err)
+	}
+
+	// A refused edit must annotate: the run exits 0, so its log is the one
+	// nobody opens and the gate would go quiet unnoticed.
+	var out bytes.Buffer
+	refused := &fakeGitHub{
+		files:    map[string]*SignatureFile{"head": file(sig("alice", 1)), "base": file(sig("alice", 1))},
+		commits:  []Commit{commit("a1", user("alice", 1), user("alice", 1), "x")},
+		posted:   []Comment{{ID: 9, Body: commentMarker + "\n## Signature required"}},
+		writeErr: errors.New("403 resource not accessible by integration"),
+	}
+	if err := newChecker(refused, &out).check(t.Context()); err != nil {
+		t.Fatalf("a failed edit must not fail a signed pull request, got %v", err)
+	}
+	if !strings.Contains(out.String(), "::warning::") {
+		t.Fatalf("want a warning annotation, got %q", out.String())
+	}
+}
+
+// A comment that merely quotes the gate is not the gate's: GitHub's quote-reply
+// copies the marker in, and editing it would silence the gate for good.
+func TestCheckIgnoresAQuotedMarker(t *testing.T) {
+	gh := &fakeGitHub{
+		files:   map[string]*SignatureFile{"head": file(), "base": file()},
+		commits: []Commit{commit("a1", user("alice", 1), user("alice", 1), "x")},
+		posted:  []Comment{{ID: 5, Body: "> " + commentMarker + "\n> ## Signature required\n\nwhy?"}},
+	}
+	if err := newChecker(gh, &bytes.Buffer{}).check(t.Context()); !errors.Is(err, errUnsigned) {
+		t.Fatalf("want errUnsigned, got %v", err)
+	}
+	if len(gh.posted) != 2 || gh.edits != 0 {
+		t.Fatalf("want its own comment posted and the quote untouched, got %d comments and %d edits", len(gh.posted), gh.edits)
+	}
+}
+
+// A gate that fell over must not leave "signed" standing on a red check, nor
+// repeat advice the contributor has just followed and failed on.
+func TestCheckReplacesItsCommentWhenTheGateCannotFinish(t *testing.T) {
+	// mallory signed but authored nothing here, so appendOnly rejects the file.
+	forged := func() *fakeGitHub {
+		return &fakeGitHub{
+			files:   map[string]*SignatureFile{"head": file(sig("mallory", 99)), "base": file()},
+			commits: []Commit{commit("a1", user("alice", 1), user("alice", 1), "x")},
+		}
+	}
+
+	gh := forged()
+	gh.posted = []Comment{{ID: 9, Body: signedComment("v1")}}
+	if err := newChecker(gh, &bytes.Buffer{}).check(t.Context()); err == nil || errors.Is(err, errUnsigned) {
+		t.Fatalf("want an append-only failure, got %v", err)
+	}
+	if gh.edits != 1 || strings.Contains(gh.posted[0].Body, "signed") {
+		t.Fatalf("want the signed note replaced, got %q after %d edits", gh.posted[0].Body, gh.edits)
+	}
+
+	// Nothing standing means nothing to correct; a bare failure is not worth a comment.
+	quiet := forged()
+	if err := newChecker(quiet, &bytes.Buffer{}).check(t.Context()); err == nil {
+		t.Fatal("want an append-only failure")
+	}
+	if len(quiet.posted) != 0 {
+		t.Fatalf("want no comment, got %+v", quiet.posted)
+	}
+}
+
+// The label is what makes CLA status visible in the pull request list, and the
+// two are mutually exclusive: a signed pull request still carrying "not signed"
+// is worse than no label at all.
+func TestCheckLabelsEachOutcome(t *testing.T) {
+	unsignedPR := func() *fakeGitHub {
+		return &fakeGitHub{
+			files:    map[string]*SignatureFile{"head": file(), "base": file()},
+			commits:  []Commit{commit("a1", user("alice", 1), user("alice", 1), "x")},
+			labelled: []string{"enhancement", labelSigned},
+		}
+	}
+	gh := unsignedPR()
+	if err := newChecker(gh, &bytes.Buffer{}).check(t.Context()); !errors.Is(err, errUnsigned) {
+		t.Fatalf("want errUnsigned, got %v", err)
+	}
+	if !slices.Equal(gh.labelled, []string{"enhancement", labelUnsigned}) {
+		t.Fatalf("want the signed label swapped out and enhancement kept, got %v", gh.labelled)
+	}
+
+	signed := &fakeGitHub{
+		files:    map[string]*SignatureFile{"head": file(sig("alice", 1)), "base": file(sig("alice", 1))},
+		commits:  []Commit{commit("a1", user("alice", 1), user("alice", 1), "x")},
+		labelled: []string{labelUnsigned},
+	}
+	if err := newChecker(signed, &bytes.Buffer{}).check(t.Context()); err != nil {
+		t.Fatalf("want a pass, got %v", err)
+	}
+	if !slices.Equal(signed.labelled, []string{labelSigned}) {
+		t.Fatalf("want only the signed label, got %v", signed.labelled)
+	}
+
+	// A gate that could not finish knows nothing, but must not leave "signed"
+	// standing on a red check.
+	broken := &fakeGitHub{
+		files:    map[string]*SignatureFile{"head": file(sig("mallory", 99)), "base": file()},
+		commits:  []Commit{commit("a1", user("alice", 1), user("alice", 1), "x")},
+		labelled: []string{labelSigned},
+	}
+	if err := newChecker(broken, &bytes.Buffer{}).check(t.Context()); err == nil || errors.Is(err, errUnsigned) {
+		t.Fatalf("want an append-only failure, got %v", err)
+	}
+	if len(broken.labelled) != 0 {
+		t.Fatalf("want the signed label dropped, got %v", broken.labelled)
+	}
+}
+
+// A label event notifies everyone watching the pull request, so a run that
+// changes nothing must write nothing.
+func TestCheckDoesNotRewriteACorrectLabel(t *testing.T) {
+	gh := &fakeGitHub{
+		files:    map[string]*SignatureFile{"head": file(), "base": file()},
+		commits:  []Commit{commit("a1", user("alice", 1), user("alice", 1), "x")},
+		labelled: []string{labelUnsigned},
+	}
+	if err := newChecker(gh, &bytes.Buffer{}).check(t.Context()); !errors.Is(err, errUnsigned) {
+		t.Fatalf("want errUnsigned, got %v", err)
+	}
+	if gh.labelWrites != 0 {
+		t.Fatalf("want no label write, got %d", gh.labelWrites)
 	}
 }

--- a/tools/clacheck/report.go
+++ b/tools/clacheck/report.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 )
@@ -13,7 +15,12 @@ const placeholderName = "Your Name"
 type report struct {
 	text     string // job log, plus the ::error:: annotation shown on the checks page
 	markdown string // job summary, rendered on the checks page without opening the log
+	comment  string // pull request comment, the only report seen without opening the job log
 }
+
+// commentMarker identifies the gate's own comment so a re-run edits it instead of
+// posting another. It is invisible in the rendered comment.
+const commentMarker = "<!-- clacheck:signature-request -->"
 
 func entryJSON(p Principal, version, indent string, now time.Time) string {
 	return fmt.Sprintf(`%s{ "login": %q,
@@ -27,7 +34,8 @@ func entryJSON(p Principal, version, indent string, now time.Time) string {
 // unsignedReport is what a contributor actually meets when the gate fails. It
 // carries their entry already filled in, so signing is a copy and a commit rather
 // than a hunt through documentation for a numeric id they have never needed.
-func unsignedReport(cfg config, version string, missing []Principal, now time.Time) report {
+func unsignedReport(cfg config, head *SignatureFile, missing []Principal, now time.Time) report {
+	version := head.CLAVersion
 	logins := make([]string, len(missing))
 	for i, p := range missing {
 		logins[i] = p.Login
@@ -46,26 +54,101 @@ func unsignedReport(cfg config, version string, missing []Principal, now time.Ti
 	fmt.Fprintf(&text, "Replace %q with your own name, then commit it and push — that commit is\n", placeholderName)
 	fmt.Fprintf(&text, "your signature. You only do it once per CLA version.\n")
 
+	whole, ok := signedFile(head, missing, now)
+	return report{
+		text:     text.String(),
+		markdown: signMarkdown(claURL, head, missing, now, whole, ok, 0),
+		comment:  commentMarker + "\n" + signMarkdown(claURL, head, missing, now, whole, ok, cfg.opener.ID),
+	}
+}
+
+// Only mentionID is mentioned: every other login can be invented by a
+// Co-authored-by trailer, which would let a pull request notify anyone it names.
+func signMarkdown(claURL string, head *SignatureFile, missing []Principal, now time.Time, whole string, wholeFits bool, mentionID int64) string {
+	version := head.CLAVersion
+	named := make([]string, len(missing))
+	for i, p := range missing {
+		if named[i] = p.Login; p.ID == mentionID {
+			named[i] = "@" + p.Login
+		}
+	}
+	entries := plural(len(missing), "this entry", "these entries")
+
 	var md strings.Builder
 	fmt.Fprintf(&md, "## Signature required\n\n")
 	fmt.Fprintf(&md, "Thanks for contributing! Before this can merge, everyone whose work is in this "+
 		"pull request needs to have signed the [Contributor License Agreement](%s).\n\n", claURL)
-	fmt.Fprintf(&md, "**Not signed yet:** %s\n\n", strings.Join(logins, ", "))
+	fmt.Fprintf(&md, "**Not signed yet:** %s\n\n", strings.Join(named, ", "))
 	fmt.Fprintf(&md, "### How to sign\n\n")
-	fmt.Fprintf(&md, "Add %s to the `signatures` array in `signatures/cla.json`, replacing `%s`:\n\n", entries, placeholderName)
-	fmt.Fprintf(&md, "```json\n")
-	for i, p := range missing {
-		if i > 0 {
-			md.WriteString(",\n")
+	if wholeFits {
+		fmt.Fprintf(&md, "Copy this over the whole of `signatures/cla.json`, replacing `%s` with your own:\n\n", placeholderName)
+		fmt.Fprintf(&md, "```json\n%s```\n\n", whole)
+	} else {
+		fmt.Fprintf(&md, "Add %s to the `signatures` array in `signatures/cla.json`, %s:\n\n", entries,
+			plural(len(missing), "replacing `"+placeholderName+"` with your own name",
+				"replacing each `"+placeholderName+"` with that person's own name"))
+		fmt.Fprintf(&md, "```json\n")
+		for i, p := range missing {
+			if i > 0 {
+				md.WriteString(",\n")
+			}
+			md.WriteString(entryJSON(p, version, "", now))
 		}
-		md.WriteString(entryJSON(p, version, "", now))
+		fmt.Fprintf(&md, "\n```\n\n")
 	}
-	fmt.Fprintf(&md, "\n```\n\n")
 	fmt.Fprintf(&md, "Commit that to this pull request and push. Your id is already filled in above — "+
 		"it identifies you even if you later change your username.\n\n")
 	fmt.Fprintf(&md, "You sign **once** per CLA version. It covers everything you contribute here afterwards.\n")
 
-	return report{text: text.String(), markdown: md.String()}
+	return md.String()
+}
+
+// fullFileMaxSignatures caps the paste-the-whole-file form. Past it the comment
+// would be longer than the change it asks for, so the entry is shown alone.
+const fullFileMaxSignatures = 20
+
+// Existing entries are reproduced verbatim, so pasting it is append-only. Single
+// signer only: of two placeholders, whoever pastes fills in one and validate
+// rejects the other on the next run.
+func signedFile(head *SignatureFile, missing []Principal, now time.Time) (string, bool) {
+	if len(missing) != 1 || len(head.Signatures) > fullFileMaxSignatures {
+		return "", false
+	}
+	out := *head
+	out.Signatures = slices.Clone(head.Signatures)
+	for _, p := range missing {
+		out.Signatures = append(out.Signatures, Signature{
+			Login: p.Login,
+			ID:    p.ID,
+			Name:  placeholderName,
+			Date:  now.UTC().Format(time.DateOnly),
+			CLA:   head.CLAVersion,
+		})
+	}
+	b, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return "", false
+	}
+	return string(b) + "\n", true
+}
+
+// The gate's two labels. They are mutually exclusive, so setting one clears the
+// other; create them in the repository so they get a deliberate colour.
+const (
+	labelSigned   = "cla: signed"
+	labelUnsigned = "cla: not signed"
+)
+
+// signedComment replaces a request comment once the signature lands, so a merged
+// pull request is not left showing a demand that has already been met.
+func signedComment(version string) string {
+	return fmt.Sprintf("%s\nCLA %s signed — thanks!\n", commentMarker, version)
+}
+
+// The error itself is left to the log: it can quote a login out of the pull
+// request's own file, which would break out of any markup used here.
+func problemComment() string {
+	return commentMarker + "\nThe CLA check did not finish. See the job log on the checks tab for what went wrong.\n"
 }
 
 func plural(n int, one, many string) string {

--- a/tools/clacheck/report_test.go
+++ b/tools/clacheck/report_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -11,7 +12,7 @@ func reportCfg() config {
 }
 
 func TestUnsignedReportFillsInTheContributorsEntry(t *testing.T) {
-	r := unsignedReport(reportCfg(), "v1", []Principal{{ID: 42, Login: "carol", Type: "User"}}, fixedNow)
+	r := unsignedReport(reportCfg(), file(), []Principal{{ID: 42, Login: "carol", Type: "User"}}, fixedNow)
 
 	if !strings.HasPrefix(r.text, "::error::CLA v1 not signed by: carol\n") {
 		t.Fatalf("the annotation must be the first line, got %q", r.text)
@@ -20,6 +21,10 @@ func TestUnsignedReportFillsInTheContributorsEntry(t *testing.T) {
 		if !strings.Contains(r.text, want) {
 			t.Errorf("want %q in the log report", want)
 		}
+	}
+	// The summary carries the file as it should be committed, so it is marshaled
+	// rather than aligned by hand.
+	for _, want := range []string{`"login": "carol"`, `"id": 42`, `"date": "2026-08-30"`, `"cla": "v1"`} {
 		if !strings.Contains(r.markdown, want) {
 			t.Errorf("want %q in the job summary", want)
 		}
@@ -30,29 +35,27 @@ func TestUnsignedReportFillsInTheContributorsEntry(t *testing.T) {
 	}
 }
 
-// The summary's code block is meant to be pasted straight into the signatures
-// array, so it has to parse as array elements — not just look like JSON.
+// The code block is meant to replace signatures/cla.json outright, so it has to
+// parse as that whole file — not merely look like JSON.
 func TestUnsignedReportEmitsPasteableJSON(t *testing.T) {
-	r := unsignedReport(reportCfg(), "v1", []Principal{
-		{ID: 42, Login: "carol", Type: "User"},
-		{ID: 7, Login: "dave", Type: "User"},
-	}, fixedNow)
+	r := unsignedReport(reportCfg(), file(), []Principal{{ID: 42, Login: "carol", Type: "User"}}, fixedNow)
 
 	_, block, ok := strings.Cut(r.markdown, "```json\n")
 	if !ok {
 		t.Fatalf("want a json block in the summary, got %q", r.markdown)
 	}
-	block, _, ok = strings.Cut(block, "\n```")
+	block, _, ok = strings.Cut(block, "```")
 	if !ok {
 		t.Fatalf("want the json block to be closed, got %q", r.markdown)
 	}
 
-	var entries []Signature
-	if err := json.Unmarshal([]byte("["+block+"]"), &entries); err != nil {
-		t.Fatalf("the block does not paste into the signatures array: %v\n%s", err, block)
+	var pasted SignatureFile
+	if err := json.Unmarshal([]byte(block), &pasted); err != nil {
+		t.Fatalf("the block is not a usable signatures/cla.json: %v\n%s", err, block)
 	}
-	if len(entries) != 2 || entries[0].ID != 42 || entries[1].ID != 7 {
-		t.Fatalf("want both entries with their ids, got %+v", entries)
+	entries := pasted.Signatures
+	if len(entries) != 1 || entries[0].ID != 42 {
+		t.Fatalf("want carol's entry with her id, got %+v", entries)
 	}
 	for _, e := range entries {
 		if e.Name != "Your Name" || e.CLA != "v1" || e.Date != "2026-08-30" {
@@ -67,5 +70,121 @@ func TestPlural(t *testing.T) {
 	}
 	if got := plural(2, "this entry", "these entries"); got != "these entries" {
 		t.Fatalf("want the plural, got %q", got)
+	}
+}
+
+// A login other than the opener's can be invented by a Co-authored-by trailer, so
+// mentioning one would let any pull request make the bot notify anyone it names.
+// Only the opener, whom the webhook supplies, is mentioned.
+func TestOnlyTheOpenerIsMentioned(t *testing.T) {
+	cfg := reportCfg()
+	cfg.opener = Principal{ID: 42, Login: "carol", Type: "User"}
+	r := unsignedReport(cfg, file(), []Principal{
+		{ID: 42, Login: "carol", Type: "User"},
+		{ID: 7, Login: "torvalds", Type: "User"},
+	}, fixedNow)
+
+	if !strings.Contains(r.comment, "@carol") {
+		t.Errorf("the comment must mention the opener, got %q", r.comment)
+	}
+	if strings.Contains(r.comment, "@torvalds") {
+		t.Errorf("a co-author must not be mentioned, got %q", r.comment)
+	}
+	if strings.Contains(r.markdown, "@carol") {
+		t.Errorf("the job summary must not mention, got %q", r.markdown)
+	}
+	if !strings.HasPrefix(r.comment, commentMarker) {
+		t.Errorf("the comment must carry the marker so a re-run finds it, got %q", r.comment)
+	}
+	if !strings.HasPrefix(signedComment("v1"), commentMarker) {
+		t.Error("the signed note must carry the marker too, or it posts as a second comment")
+	}
+}
+
+// Pasting the block must not cost anyone their signature: the whole-file form
+// reproduces the entries already there, which is what appendOnly demands back.
+func TestWholeFileFormKeepsExistingSignatures(t *testing.T) {
+	head := file(sig("alice", 1))
+	head.Comment = "append-only"
+	r := unsignedReport(reportCfg(), head, []Principal{{ID: 42, Login: "carol", Type: "User"}}, fixedNow)
+
+	_, block, _ := strings.Cut(r.comment, "```json\n")
+	block, _, _ = strings.Cut(block, "```")
+
+	var pasted SignatureFile
+	if err := json.Unmarshal([]byte(block), &pasted); err != nil {
+		t.Fatalf("the block is not a usable signatures/cla.json: %v", err)
+	}
+	if pasted.Comment != head.Comment || pasted.CLAVersion != "v1" {
+		t.Fatalf("want the file's own fields carried over, got %+v", pasted)
+	}
+	if len(pasted.Signatures) != 2 || pasted.Signatures[0] != head.Signatures[0] {
+		t.Fatalf("want alice reproduced verbatim and carol appended, got %+v", pasted.Signatures)
+	}
+	// The one edit left to the contributor is their name; everything else the
+	// gate will accept as it stands.
+	if err := pasted.validate(); err == nil || !strings.Contains(err.Error(), "placeholder") {
+		t.Fatalf("want the placeholder to be the only thing left to fix, got %v", err)
+	}
+	pasted.Signatures[1].Name = "Carol Danvers"
+	if err := pasted.validate(); err != nil {
+		t.Fatalf("the pasted file must pass once named: %v", err)
+	}
+	if err := appendOnly(head, &pasted, map[int64]bool{42: true}); err != nil {
+		t.Fatalf("following the instructions must satisfy the gate: %v", err)
+	}
+}
+
+// The two forms are told apart by what the block parses as, not by the prose
+// above it: reword that sentence and a phrasing assertion passes vacuously.
+func wholeFileForm(t *testing.T, comment string) bool {
+	t.Helper()
+	_, block, ok := strings.Cut(comment, "```json\n")
+	if !ok {
+		t.Fatalf("want a json block, got %q", comment)
+	}
+	block, _, _ = strings.Cut(block, "```")
+	var f SignatureFile
+	return json.Unmarshal([]byte(block), &f) == nil && f.CLAVersion != ""
+}
+
+// A file past the cap falls back to the entry alone: a comment reproducing every
+// existing signature buries the one line the contributor has to add.
+func TestLongSignatureFileFallsBackToTheEntryForm(t *testing.T) {
+	long, atCap := file(), file()
+	for i := range fullFileMaxSignatures + 1 {
+		long.Signatures = append(long.Signatures, sig(fmt.Sprintf("dev%d", i), int64(i+100)))
+		if i < fullFileMaxSignatures {
+			atCap.Signatures = append(atCap.Signatures, sig(fmt.Sprintf("dev%d", i), int64(i+100)))
+		}
+	}
+	carol := []Principal{{ID: 42, Login: "carol", Type: "User"}}
+
+	r := unsignedReport(reportCfg(), long, carol, fixedNow)
+	if wholeFileForm(t, r.comment) {
+		t.Fatalf("want the entry form past the cap, got %q", r.comment)
+	}
+	if !strings.Contains(r.comment, `"id":    42`) {
+		t.Fatalf("want carol's entry to append, got %q", r.comment)
+	}
+	// The cap is exclusive, so exactly fullFileMaxSignatures still fits.
+	if !wholeFileForm(t, unsignedReport(reportCfg(), atCap, carol, fixedNow).comment) {
+		t.Fatal("want the whole-file form at exactly the cap")
+	}
+}
+
+// Two placeholders in one pasted file is a trap: whoever pastes it fills in their
+// own name, and the other fails validate on the next run before any report runs.
+func TestMultipleSignersFallBackToTheEntryForm(t *testing.T) {
+	r := unsignedReport(reportCfg(), file(), []Principal{
+		{ID: 42, Login: "carol", Type: "User"},
+		{ID: 7, Login: "dave", Type: "User"},
+	}, fixedNow)
+
+	if wholeFileForm(t, r.comment) {
+		t.Fatalf("want the entry form for two signers, got %q", r.comment)
+	}
+	if !strings.Contains(r.comment, "replacing each") {
+		t.Fatalf("want the instruction to name every placeholder, got %q", r.comment)
 	}
 }


### PR DESCRIPTION
The gate only spoke through a job log a contributor has to go looking for. It now keeps one marked comment and one of two labels in sync with the verdict, both best-effort so neither can change the exit code, and mentions only the pull request opener because any other login can be invented by a trailer.