### PR TITLE
ci(cla): close version and trailer injection holes in the gate

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -193,7 +193,6 @@ Signing is a commit. Add yourself to
 ```json
 { "login": "your-github-username",
   "id":    12345678,
-  "name":  "Your Name",
   "date":  "YYYY-MM-DD",
   "cla":   "v1" }
 ```
@@ -212,15 +211,25 @@ that identifies you here, because usernames can be changed and re-registered.
 
 A status check verifies that the pull request author, every commit author and
 committer, and everyone named in a `Co-authored-by:` trailer appears in that file.
+A trailer has to carry the `<id>+<login>@users.noreply.github.com` address GitHub
+writes, since that is the only form the check can resolve to an account.
 The file is append-only: the check rejects a pull request that edits or removes an
-existing signature, or that signs on behalf of someone who authored none of its
-commits.
+existing signature.
+
+You sign for yourself, and only in a pull request you opened — the check accepts no
+other entry. A commit author, a committer and a `Co-authored-by:` trailer are all
+things the commit itself asserts, so a pull request that could sign for any of them
+could sign for anyone it chose to name. If you co-wrote a contribution with someone
+who has not signed, they sign in a pull request of their own. A trailer naming an
+AI assistant is ignored: an assistant holds no copyright, so there is nothing for
+it to license or to sign.
 
 If this Agreement is amended, the new text is published under a new version number
 and contributors are asked to sign again; a signature records the version it was
 given against and never carries over to a later one. Your earlier signature stays
 in the file as the record of what you agreed to then — you add an entry for the
-new version rather than editing the old one.
+new version rather than editing the old one, and the check accepts a new entry
+only at the version then in force.
 
 ## Third-party material
 

--- a/CLA.md
+++ b/CLA.md
@@ -211,8 +211,9 @@ that identifies you here, because usernames can be changed and re-registered.
 
 A status check verifies that the pull request author, every commit author and
 committer, and everyone named in a `Co-authored-by:` trailer appears in that file.
-A trailer has to carry the `<id>+<login>@users.noreply.github.com` address GitHub
-writes, since that is the only form the check can resolve to an account.
+A trailer has to carry a GitHub noreply address — `<login>@users.noreply.github.com`,
+or the `<id>+<login>` form GitHub writes itself — since that is the only shape the
+check can resolve to an account.
 The file is append-only: the check rejects a pull request that edits or removes an
 existing signature.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,11 +90,11 @@ from the failed check. You do it once per CLA version; it covers everything you
 contribute afterwards.
 
 A `Co-authored-by:` trailer naming a person means they have to sign too, in a pull
-request of their own. Use the `<id>+<login>@users.noreply.github.com` address
-GitHub itself writes — it is the only form the check can resolve to an account, and
-a trailer it cannot identify blocks the pull request whether or not that person has
-signed. One naming an AI assistant is ignored — it holds no copyright — so there is
-no need to rewrite commits to strip it.
+request of their own. Use a GitHub noreply address — `<login>@users.noreply.github.com`
+or the `<id>+<login>` form GitHub itself writes. That is the only shape the check
+can resolve to an account, and a trailer it cannot identify blocks the pull request
+whether or not that person has signed. One naming an AI assistant is ignored — it
+holds no copyright — so there is no need to rewrite commits to strip it.
 
 The file is append-only, and CI enforces it: an existing entry can't be edited or
 removed, the only entry you can add is your own — in a pull request you opened, so

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,19 @@ check prints the entry for you, with your GitHub id already filled in — copy i
 from the failed check. You do it once per CLA version; it covers everything you
 contribute afterwards.
 
+A `Co-authored-by:` trailer naming a person means they have to sign too, in a pull
+request of their own. Use the `<id>+<login>@users.noreply.github.com` address
+GitHub itself writes — it is the only form the check can resolve to an account, and
+a trailer it cannot identify blocks the pull request whether or not that person has
+signed. One naming an AI assistant is ignored — it holds no copyright — so there is
+no need to rewrite commits to strip it.
+
+The file is append-only, and CI enforces it: an existing entry can't be edited or
+removed, the only entry you can add is your own — in a pull request you opened, so
+a co-author signs in one of their own — and `cla_version` is set on the base branch
+rather than by a contribution, so a new signature is always recorded against the
+version in force.
+
 **You keep your copyright.** The CLA is a license, not an assignment — you stay
 free to use and relicense your own work however you like. What it adds on top of
 the AGPL is the right for us to also offer Pug under separate commercial terms to

--- a/signatures/cla.json
+++ b/signatures/cla.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Signatures for CLA.md. Append yourself in your own pull request; that commit is the signature. This file is append-only and CI enforces it: an existing entry may not be edited in any field or removed, you may only add an entry for someone GitHub attributes a commit in the same pull request to, and cla_version is set on the base branch rather than by a contribution. You are matched on the immutable numeric GitHub id, once per cla_version.",
   "cla_version": "v1",
   "signatures": []
 }

--- a/tools/clacheck/check.go
+++ b/tools/clacheck/check.go
@@ -15,13 +15,11 @@ import (
 type Signature struct {
 	Login string `json:"login"`
 	ID    int64  `json:"id"`
-	Name  string `json:"name"`
 	Date  string `json:"date"`
 	CLA   string `json:"cla"`
 }
 
 type SignatureFile struct {
-	Comment    string      `json:"_comment,omitempty"`
 	CLAVersion string      `json:"cla_version"`
 	Signatures []Signature `json:"signatures"`
 }
@@ -55,8 +53,9 @@ func validDate(s string) bool {
 	return err == nil
 }
 
-// validate rejects a signature file that records agreement to nothing: a missing
-// id, or the placeholder name the report hands out left unedited.
+// validate rejects a signature file that records agreement to nothing: an entry
+// with no id names nobody. The version is held to versionRe for the reason given
+// at its declaration — report.go interpolates it into an annotation unescaped.
 func (f *SignatureFile) validate() error {
 	if f.CLAVersion == "" {
 		return errors.New("cla_version is missing or empty")
@@ -75,10 +74,6 @@ func (f *SignatureFile) validate() error {
 			problem = "login is empty"
 		case s.ID == 0:
 			problem = "id is missing or zero"
-		case s.Name == "":
-			problem = "name is empty"
-		case s.Name == placeholderName:
-			problem = "name is still the placeholder; put your own name in"
 		case !validDate(s.Date):
 			problem = "date is not a real YYYY-MM-DD date"
 		case !versionRe.MatchString(s.CLA):
@@ -142,12 +137,27 @@ func coauthorEmails(commits []Commit) []string {
 	var out []string
 	for _, c := range commits {
 		for _, m := range coauthorRe.FindAllStringSubmatch(c.Commit.Message, -1) {
-			out = append(out, strings.ToLower(strings.TrimSpace(m[1])))
+			// A lone CR ends a line for both the Actions log and CommonMark, so
+			// leaving one in would let a trailer forge a workflow command and
+			// break out of the code span the report renders it in.
+			out = append(out, strings.ToLower(strings.TrimSpace(strings.ReplaceAll(m[1], "\r", ""))))
 		}
 	}
 	slices.Sort(out)
 	return slices.Compact(out)
 }
+
+// An assistant holds no copyright, so a trailer naming one names no principal and
+// there is nothing for it to sign. Blocking would make every contributor using one
+// rewrite their branch over a line that licenses nothing. Matched whole and
+// lowercased, which is how coauthorEmails hands an address over; add to this list
+// rather than loosening the check, so an address that might be a person still stops
+// the gate.
+var assistantEmails = []string{
+	"noreply@anthropic.com", // Claude Code's default Co-authored-by trailer
+}
+
+func isAssistant(email string) bool { return slices.Contains(assistantEmails, email) }
 
 var noreplyRe = regexp.MustCompile(`^(?:\d+\+)?([A-Za-z0-9-]+(?:\[bot\])?)@users\.noreply\.github\.com$`)
 
@@ -162,13 +172,17 @@ func noreplyLogin(email string) string {
 	return ""
 }
 
-// appendOnly enforces what the file's own comment promises: existing entries are
-// immutable, and a pull request may only sign for someone who authored part of it.
-// Without the second half, anyone could sign on a stranger's behalf.
-func appendOnly(base, head *SignatureFile, prIDs map[int64]bool) error {
-	if base.CLAVersion != "" && head.CLAVersion != base.CLAVersion {
-		return fmt.Errorf("this pull request changes cla_version from %q to %q; the version is set on the base branch, not in a contribution",
-			base.CLAVersion, head.CLAVersion)
+// appendOnly keeps existing entries immutable and takes only the opener's own
+// signature. The opener is the one principal that cannot be forged: an author, a
+// committer and a trailer are all self-asserted, so accepting a signature for any
+// principal would let a pull request sign for anyone it named.
+//
+// inForce comes from the base branch tip, not from base: a branch that predates a
+// version bump would otherwise sign the retired version and pass.
+func appendOnly(base, head *SignatureFile, signer Principal, inForce string) error {
+	if head.CLAVersion != inForce {
+		return fmt.Errorf("cla_version is %q on the base branch but %q here; it is set on the base branch, not by a contribution, so merge the base branch if this one is behind",
+			inForce, head.CLAVersion)
 	}
 	for _, b := range base.Signatures {
 		if !slices.Contains(head.Signatures, b) {
@@ -176,10 +190,20 @@ func appendOnly(base, head *SignatureFile, prIDs map[int64]bool) error {
 		}
 	}
 	for _, h := range head.Signatures {
-		if slices.Contains(base.Signatures, h) || prIDs[h.ID] {
-			continue
+		switch {
+		case slices.Contains(base.Signatures, h):
+		case h.ID != signer.ID:
+			return fmt.Errorf("this pull request adds a signature for %q, who did not open it; you may only sign for yourself, so a co-author signs in a pull request of their own", h.Login)
+		// Signing matches on the id, so a mismatched login would stand in the
+		// record as a signature by whoever it names.
+		case !strings.EqualFold(h.Login, signer.Login):
+			return fmt.Errorf("this signature records id %d under the login %q, but that id belongs to %q", h.ID, h.Login, signer.Login)
+		// You sign what is in force. A new entry at a retired version records an
+		// agreement never given, and signed() reads it as unsigned anyway.
+		case h.CLA != head.CLAVersion:
+			return fmt.Errorf("this signature is recorded against CLA %q, but %q is the version in force; sign the current one",
+				h.CLA, head.CLAVersion)
 		}
-		return fmt.Errorf("this pull request signs for %q, who authored none of its commits; you may only sign for yourself", h.Login)
 	}
 	return nil
 }

--- a/tools/clacheck/check_test.go
+++ b/tools/clacheck/check_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func sig(login string, id int64) Signature {
-	return Signature{Login: login, ID: id, Name: "N", Date: "2026-01-01", CLA: "v1"}
+	return Signature{Login: login, ID: id, Date: "2026-01-01", CLA: "v1"}
 }
 
 func file(s ...Signature) *SignatureFile {
@@ -35,8 +35,6 @@ func TestValidateRejectsSignaturesThatRecordNothing(t *testing.T) {
 	}{
 		{"missing id", func(f *SignatureFile) { f.Signatures[0].ID = 0 }, "id is missing"},
 		{"empty login", func(f *SignatureFile) { f.Signatures[0].Login = "" }, "login is empty"},
-		{"empty name", func(f *SignatureFile) { f.Signatures[0].Name = "" }, "name is empty"},
-		{"placeholder name", func(f *SignatureFile) { f.Signatures[0].Name = placeholderName }, "still the placeholder"},
 		{"bad date", func(f *SignatureFile) { f.Signatures[0].Date = "yesterday" }, "date is not a real"},
 		{"impossible day", func(f *SignatureFile) { f.Signatures[0].Date = "2026-02-30" }, "date is not a real"},
 		{"impossible month", func(f *SignatureFile) { f.Signatures[0].Date = "2026-99-99" }, "date is not a real"},
@@ -218,8 +216,8 @@ func TestNoreplyLoginDiscardsTheEmbeddedID(t *testing.T) {
 // coexist; only an entry at the file's current version counts as signed.
 func TestSignedRequiresTheCurrentVersion(t *testing.T) {
 	f := &SignatureFile{CLAVersion: "v2", Signatures: []Signature{
-		{Login: "alice", ID: 1, Name: "A", Date: "2026-01-01", CLA: "v1"},
-		{Login: "bob", ID: 2, Name: "B", Date: "2026-01-01", CLA: "v2"},
+		{Login: "alice", ID: 1, Date: "2026-01-01", CLA: "v1"},
+		{Login: "bob", ID: 2, Date: "2026-01-01", CLA: "v2"},
 	}}
 	if err := f.validate(); err != nil {
 		t.Fatalf("v1 and v2 entries must coexist: %v", err)
@@ -242,22 +240,114 @@ func TestCoauthorTrailerStopsAtTheLineEnd(t *testing.T) {
 	}
 }
 
+// A version bump retires the old text. An entry added against it would record an
+// agreement never given, into a file that is append-only and is the record.
+func TestANewSignatureMustBeAtTheVersionInForce(t *testing.T) {
+	v1 := Signature{Login: "alice", ID: 1, Date: "2025-01-01", CLA: "v1"}
+	v2 := func(s ...Signature) *SignatureFile { return &SignatureFile{CLAVersion: "v2", Signatures: s} }
+	base := v2(v1)
+	bob := Principal{ID: 2, Login: "bob", Type: "User"}
+
+	stale := v2(v1, Signature{Login: "bob", ID: 2, Date: "2026-08-31", CLA: "v1"})
+	err := appendOnly(base, stale, bob, "v2")
+	if err == nil {
+		t.Fatal("a new signature against the retired version must be rejected")
+	}
+	if !strings.Contains(err.Error(), "version in force") {
+		t.Errorf("want the current version named, got %v", err)
+	}
+	// The bump does not invalidate what came before: alice's v1 entry is the
+	// record of what she agreed to then, and stays as it is.
+	current := v2(v1, Signature{Login: "bob", ID: 2, Date: "2026-08-31", CLA: "v2"})
+	if err := appendOnly(base, current, bob, "v2"); err != nil {
+		t.Fatalf("signing the version in force must be accepted: %v", err)
+	}
+	if err := current.validate(); err != nil {
+		t.Fatalf("a v1 entry must survive the bump alongside a v2 one: %v", err)
+	}
+}
+
 func TestAppendOnly(t *testing.T) {
 	base := file(sig("alice", 1))
-	mine := map[int64]bool{2: true}
+	bob := Principal{ID: 2, Login: "bob", Type: "User"}
 
-	if err := appendOnly(base, file(sig("alice", 1), sig("bob", 2)), mine); err != nil {
+	if err := appendOnly(base, file(sig("alice", 1), sig("bob", 2)), bob, "v1"); err != nil {
 		t.Fatalf("adding your own signature is the whole point: %v", err)
 	}
-	if err := appendOnly(base, file(sig("bob", 2)), mine); err == nil {
+	if err := appendOnly(base, file(sig("bob", 2)), bob, "v1"); err == nil {
 		t.Fatal("removing someone else's signature must be rejected")
 	}
 	edited := file(sig("alice", 1), sig("bob", 2))
-	edited.Signatures[0].Name = "Someone Else"
-	if err := appendOnly(base, edited, mine); err == nil {
+	edited.Signatures[0].Date = "2020-01-01"
+	if err := appendOnly(base, edited, bob, edited.CLAVersion); err == nil {
 		t.Fatal("editing someone else's signature must be rejected")
 	}
-	if err := appendOnly(base, file(sig("alice", 1), sig("stranger", 42)), mine); err == nil {
-		t.Fatal("signing for someone who authored nothing here must be rejected")
+	if err := appendOnly(base, file(sig("alice", 1), sig("stranger", 42)), bob, "v1"); err == nil {
+		t.Fatal("signing for anyone but the opener must be rejected")
+	}
+	// GitHub folds case in a login, and the report hands out the canonical form,
+	// so a difference in case is a typo rather than a different person.
+	if err := appendOnly(base, file(sig("alice", 1), sig("BoB", 2)), bob, "v1"); err != nil {
+		t.Fatalf("a login differing only in case is the same person: %v", err)
+	}
+}
+
+// The id is what signing is matched on, so an entry pairing the opener's id with
+// somebody else's login stood in the file as a signature by that other person.
+func TestSignatureLoginMustMatchTheIDItClaims(t *testing.T) {
+	base := file()
+	bob := Principal{ID: 2, Login: "bob", Type: "User"}
+
+	err := appendOnly(base, file(sig("torvalds", 2)), bob, "v1")
+	if err == nil || !strings.Contains(err.Error(), `belongs to "bob"`) {
+		t.Fatalf("want the mismatched login rejected, got %v", err)
+	}
+}
+
+// Only the noreply form is ever looked up, so an ordinary address is unidentified
+// rather than absent from GitHub — the report must not claim a search it skipped.
+func TestOnlyTheNoreplyFormYieldsALogin(t *testing.T) {
+	for _, addr := range []string{"someone@example.com", "woof@pug.sh", "1+alice@users.noreply.github.example"} {
+		if got := noreplyLogin(addr); got != "" {
+			t.Errorf("%q is not the noreply form, got login %q", addr, got)
+		}
+	}
+	// The id in the <id>+<login> form comes out of a commit message, so the login
+	// is all that is taken from it.
+	for addr, want := range map[string]string{
+		"alice@users.noreply.github.com":             "alice",
+		"12345+alice@users.noreply.github.com":       "alice",
+		"1+dependabot[bot]@users.noreply.github.com": "dependabot[bot]",
+	} {
+		if got := noreplyLogin(addr); got != want {
+			t.Errorf("noreplyLogin(%q) = %q, want %q", addr, got, want)
+		}
+	}
+}
+
+// A lone CR ends a line for the Actions log and, per CommonMark, for the comment
+// too — so a trailer carrying one could forge a workflow command and break out of
+// the code span the report renders it in.
+func TestTrailerAddressCannotCarryACarriageReturn(t *testing.T) {
+	got := coauthorEmails([]Commit{commit("a1", nil, nil,
+		"feat\n\nCo-authored-by: M <a\r\r[click](https://evil.example)@x>\n")})
+	if len(got) != 1 {
+		t.Fatalf("want the trailer captured, got %v", got)
+	}
+	if strings.ContainsAny(got[0], "\r\n") {
+		t.Fatalf("want no line ending in the address, got %q", got[0])
+	}
+}
+
+// The version in force is the base branch's, not the merge base's: a branch cut
+// before a bump would otherwise sign the retired version and pass.
+func TestABranchBehindAVersionBumpCannotSignTheRetiredOne(t *testing.T) {
+	mergeBase := file(sig("alice", 1))
+	head := file(sig("alice", 1), sig("bob", 2))
+	bob := Principal{ID: 2, Login: "bob", Type: "User"}
+
+	err := appendOnly(mergeBase, head, bob, "v2")
+	if err == nil || !strings.Contains(err.Error(), "merge the base branch") {
+		t.Fatalf("want the stale version rejected with the way out, got %v", err)
 	}
 }

--- a/tools/clacheck/github.go
+++ b/tools/clacheck/github.go
@@ -167,28 +167,6 @@ func (c *client) userByLogin(ctx context.Context, login string) (Principal, erro
 	return p, nil
 }
 
-// userByEmail only accepts an unambiguous match. Anything else is reported as
-// unresolved so the contributor is asked, rather than the check quietly passing.
-func (c *client) userByEmail(ctx context.Context, email string) (Principal, error) {
-	endpoint := c.baseURL + "/search/users?q=" + url.QueryEscape(email+" in:email")
-	body, _, err := c.get(ctx, endpoint, "application/vnd.github+json")
-	if err != nil {
-		return Principal{}, err
-	}
-	var res struct {
-		Items []Principal `json:"items"`
-	}
-	if err := json.Unmarshal(body, &res); err != nil {
-		slog.ErrorContext(ctx, "an email search did not decode", errAttr(err))
-		return Principal{}, err
-	}
-	if len(res.Items) != 1 {
-		slog.DebugContext(ctx, "email search was not unambiguous", slog.Int("matches", len(res.Items)))
-		return Principal{}, errNotFound
-	}
-	return res.Items[0], nil
-}
-
 // Comment is the gate's own pull request comment, matched by its marker rather
 // than by author: the token's identity differs between a GitHub App and Actions.
 type Comment struct {

--- a/tools/clacheck/github_test.go
+++ b/tools/clacheck/github_test.go
@@ -74,13 +74,37 @@ func TestGetSurfacesAnUnexpectedStatus(t *testing.T) {
 	}
 }
 
-// userByEmail deliberately refuses an ambiguous match rather than picking one.
-func TestUserByEmailRefusesAnAmbiguousMatch(t *testing.T) {
-	c := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
-		fmt.Fprint(w, `{"items":[{"id":1,"login":"a"},{"id":2,"login":"b"}]}`)
+// userByLogin is the whole of co-author identity now, and resolveCoauthors keys
+// its unknown-vs-error split on the errNotFound this returns.
+func TestUserByLoginResolvesAndReportsAMissingAccount(t *testing.T) {
+	var got string
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Path
+		if strings.Contains(r.URL.Path, "ghost") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		fmt.Fprint(w, `{"id":99,"login":"alice","type":"User"}`)
 	})
-	if _, err := c.userByEmail(t.Context(), "shared@example.com"); !errors.Is(err, errNotFound) {
-		t.Fatalf("want errNotFound for two matches, got %v", err)
+
+	p, err := c.userByLogin(t.Context(), "alice")
+	if err != nil || p.ID != 99 || p.Login != "alice" {
+		t.Fatalf("want alice resolved, got %+v %v", p, err)
+	}
+	if got != "/users/alice" {
+		t.Fatalf("want the users endpoint, got %q", got)
+	}
+
+	if _, err := c.userByLogin(t.Context(), "ghost"); !errors.Is(err, errNotFound) {
+		t.Fatalf("want errNotFound for a missing account, got %v", err)
+	}
+
+	// A bot co-author reaches here by design: noreplyRe keeps the [bot] suffix.
+	if _, err := c.userByLogin(t.Context(), "dependabot[bot]"); err != nil {
+		t.Fatalf("want the login path-escaped, got %v", err)
+	}
+	if got != "/users/dependabot[bot]" {
+		t.Fatalf("want the bot login escaped onto the path, got %q", got)
 	}
 }
 

--- a/tools/clacheck/main.go
+++ b/tools/clacheck/main.go
@@ -4,7 +4,8 @@
 // commit author, committer, co-author, and the person who opened it — must appear
 // in signatures/cla.json. The file is read from the pull request's own head, so a
 // contributor signs in the same pull request; the edit must be append-only and may
-// only add people who authored one of its commits.
+// only add the person who opened it, so a co-author signs in a pull request of
+// their own.
 //
 // Commits and the signature file are read over the API, so no file the pull
 // request controls is read off the runner. The checker's own code and workflow are
@@ -87,20 +88,21 @@ func loadConfig() (config, error) {
 		return c, errors.New("GH_TOKEN is empty")
 	case c.opener.ID == 0:
 		return c, errors.New("PR_USER_ID is zero")
+	case c.opener.Login == "":
+		return c, errors.New("PR_USER_LOGIN is empty")
 	}
 	return c, nil
 }
 
 // githubAPI is the GitHub surface the gate depends on, named consumer-side so
 // the check can be unit-tested against a fake instead of the live API. Every
-// implementation must report a missing resource as errNotFound: check reads it
-// as the first-contributor case rather than a failure.
+// implementation must report a missing resource as errNotFound: resolveCoauthors
+// reads it as "no such account" rather than as an API failure.
 type githubAPI interface {
 	signatureFile(ctx context.Context, ref string) (*SignatureFile, error)
 	pullCommits(ctx context.Context, pr int) ([]Commit, error)
 	mergeBase(ctx context.Context, base, head string) (string, error)
 	userByLogin(ctx context.Context, login string) (Principal, error)
-	userByEmail(ctx context.Context, email string) (Principal, error)
 	comments(ctx context.Context, pr int) ([]Comment, error)
 	createComment(ctx context.Context, pr int, body string) error
 	updateComment(ctx context.Context, id int64, body string) error
@@ -168,7 +170,8 @@ func (c *checker) verdict(ctx context.Context) error {
 
 	head, err := c.gh.signatureFile(ctx, c.cfg.headSHA)
 	if err != nil {
-		return fmt.Errorf("reading signatures/cla.json at the pull request head: %w", err)
+		return fmt.Errorf("reading signatures/cla.json at the pull request head: %w\n"+
+			"If this branch predates the file, merging %s brings it in", err, c.cfg.baseRef)
 	}
 	if err := head.validate(); err != nil {
 		return fmt.Errorf("signatures/cla.json is invalid: %w", err)
@@ -192,11 +195,12 @@ func (c *checker) verdict(ctx context.Context) error {
 			strings.Join(unlinked, ", "), c.cfg.serverURL)
 	}
 
-	coauthors, unresolved := c.resolveCoauthors(ctx, commits)
-	if len(unresolved) > 0 {
-		return fmt.Errorf("these Co-authored-by addresses did not resolve to a GitHub account: %s\n"+
-			"A co-author holds copyright and must sign too; use their <id>+<login>@users.noreply.github.com address or drop the trailer. If GitHub's API was erroring, re-running the job is enough",
-			strings.Join(unresolved, ", "))
+	// An unidentified co-author blocks the gate like an unsigned one — a trailer
+	// names a copyright holder either way — but is reported rather than raised: it
+	// is the contributor's to fix, and a checker error would bury the report.
+	coauthors, unknown, err := c.resolveCoauthors(ctx, commits)
+	if err != nil {
+		return err
 	}
 	people = append(people, coauthors...)
 
@@ -204,17 +208,22 @@ func (c *checker) verdict(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	prIDs := make(map[int64]bool, len(people))
-	for _, p := range people {
-		prIDs[p.ID] = true
+	inForce, err := c.gh.signatureFile(ctx, c.cfg.baseSHA)
+	if err != nil {
+		return fmt.Errorf("reading signatures/cla.json on %s: %w", c.cfg.baseRef, err)
 	}
-	if err := appendOnly(base, head, prIDs); err != nil {
-		return err
+	if err := appendOnly(base, head, c.cfg.opener, inForce.CLAVersion); err != nil {
+		// A rejected edit is the contributor's to fix, like an unsigned CLA, so it
+		// takes the same label and comment rather than reading as a broken gate.
+		fmt.Fprintf(c.out, "::error::%s\n", escapeAnnotation(err.Error()))
+		c.upsertComment(ctx, rejectedComment(), true)
+		c.syncLabels(ctx, labelUnsigned, labelSigned)
+		return errUnsigned
 	}
 
 	missing, checked := unsigned(head, people)
-	if len(missing) > 0 {
-		report := unsignedReport(c.cfg, head, missing, c.now())
+	if len(missing) > 0 || len(unknown) > 0 {
+		report := unsignedReport(c.cfg, head, missing, unknown, c.now())
 		fmt.Fprint(c.out, report.text)
 		c.writeSummary(ctx, report.markdown)
 		c.upsertComment(ctx, report.comment, true)
@@ -312,10 +321,7 @@ func (c *checker) baseFile(ctx context.Context) (*SignatureFile, error) {
 		return nil, fmt.Errorf("finding where this pull request left %s: %w", c.cfg.baseRef, err)
 	}
 	base, err := c.gh.signatureFile(ctx, mergeBase)
-	switch {
-	case errors.Is(err, errNotFound):
-		return &SignatureFile{Signatures: []Signature{}}, nil
-	case err != nil:
+	if err != nil {
 		return nil, fmt.Errorf("reading signatures/cla.json at %s: %w", mergeBase, err)
 	}
 	return base, nil
@@ -323,30 +329,39 @@ func (c *checker) baseFile(ctx context.Context) (*SignatureFile, error) {
 
 // resolveCoauthors turns Co-authored-by trailers into principals. A trailer is
 // commit-message text, so nothing in it is taken on trust — the address only
-// chooses which lookup runs, and the id always comes back from the API.
-func (c *checker) resolveCoauthors(ctx context.Context, commits []Commit) (found []Principal, unresolved []string) {
+// chooses which login is looked up, and the id always comes back from the API.
+//
+// Only the noreply form is resolved. Any other address would have to go through
+// user search, which sees only emails public on a profile, so it answers for a
+// minority of people and spends the strictest rate limit we touch to do it; a
+// commit's own author needs none of this, because GitHub resolves that one
+// server-side against emails we cannot see.
+//
+// An unresolved address comes back as unknown for the report; an API that failed
+// to answer is an error instead, since "we could not reach GitHub" must not reach
+// the contributor as "your co-author has not signed". A known assistant is
+// neither: it names no copyright holder, so it is skipped rather than reported.
+func (c *checker) resolveCoauthors(ctx context.Context, commits []Commit) (found []Principal, unknown []string, err error) {
 	for _, email := range coauthorEmails(commits) {
-		var (
-			p   Principal
-			err error
-		)
-		if login := noreplyLogin(email); login != "" {
-			p, err = c.gh.userByLogin(ctx, login)
-		} else {
-			p, err = c.gh.userByEmail(ctx, email)
+		if isAssistant(email) {
+			continue
 		}
+		login := noreplyLogin(email)
+		if login == "" {
+			unknown = append(unknown, email)
+			continue
+		}
+		p, err := c.gh.userByLogin(ctx, login)
 		if err != nil && !errors.Is(err, errNotFound) {
-			// The contributor is told the same thing either way; only the log
-			// separates "no such account" from a rate limit or an outage.
-			slog.WarnContext(ctx, "co-author lookup failed", slog.String("email", email), errAttr(err))
+			return nil, nil, fmt.Errorf("resolving the co-author %s: %w\nIf GitHub's API was erroring, re-running the job is enough", email, err)
 		}
 		if err != nil || p.ID == 0 {
-			unresolved = append(unresolved, email)
+			unknown = append(unknown, email)
 			continue
 		}
 		found = append(found, p)
 	}
-	return found, unresolved
+	return found, unknown, nil
 }
 
 // writeSummary is best-effort: the summary is presentation, and the verdict is

--- a/tools/clacheck/main_test.go
+++ b/tools/clacheck/main_test.go
@@ -19,7 +19,6 @@ type fakeGitHub struct {
 	files     map[string]*SignatureFile
 	commits   []Commit
 	byLogin   map[string]Principal
-	byEmail   map[string]Principal
 	lookupErr error
 	base      string // ref check should read the base file at; defaults to "base"
 
@@ -53,16 +52,6 @@ func (f *fakeGitHub) userByLogin(_ context.Context, login string) (Principal, er
 		return Principal{}, f.lookupErr
 	}
 	if p, ok := f.byLogin[login]; ok {
-		return p, nil
-	}
-	return Principal{}, errNotFound
-}
-
-func (f *fakeGitHub) userByEmail(_ context.Context, email string) (Principal, error) {
-	if f.lookupErr != nil {
-		return Principal{}, f.lookupErr
-	}
-	if p, ok := f.byEmail[email]; ok {
 		return p, nil
 	}
 	return Principal{}, errNotFound
@@ -171,10 +160,15 @@ func TestCheckReportsTheUnsignedContributor(t *testing.T) {
 	if !strings.HasPrefix(out.String(), "::error::") {
 		t.Fatalf("the report must open with the annotation, got %q", out.String())
 	}
-	for _, want := range []string{"alice", "bob", `"id":    2`} {
+	// alice opened it, so hers is the entry offered; bob authored the commit and
+	// is named, but only he can sign for himself.
+	for _, want := range []string{"alice", "bob", `"id":    1`, "opened themselves"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("want %q in the report, got %q", want, out.String())
 		}
+	}
+	if strings.Contains(out.String(), `"id":    2`) {
+		t.Fatalf("bob must not be handed an entry this pull request cannot add, got %q", out.String())
 	}
 }
 
@@ -207,22 +201,81 @@ func TestCheckWritesTheJobSummary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading the summary: %v", err)
 	}
-	if !strings.Contains(string(body), "## Signature required") {
+	if !strings.Contains(string(body), "## CLA signature required") {
 		t.Fatalf("want the summary heading, got %q", body)
 	}
 }
 
-// A failed lookup and a genuinely unknown account reach the contributor as the
-// same message, so the failure must at least be counted as unresolved rather
-// than dropping the co-author from the check entirely.
-func TestResolveCoauthorsTreatsALookupFailureAsUnresolved(t *testing.T) {
+// A rate limit is not evidence that carol has no account, so it must not reach
+// her as "unidentified" — that sends the contributor off to fix an address that
+// was fine. It is the checker's fault and is raised as one.
+func TestResolveCoauthorsRaisesALookupFailure(t *testing.T) {
+	commits := []Commit{commit("a1", user("alice", 1), user("alice", 1),
+		"feat: thing\n\nCo-authored-by: Carol <carol@users.noreply.github.com>\n")}
+
+	c := newChecker(&fakeGitHub{lookupErr: errors.New("403 rate limit exceeded")}, &bytes.Buffer{})
+	_, unknown, err := c.resolveCoauthors(t.Context(), commits)
+	if err == nil || len(unknown) != 0 {
+		t.Fatalf("want the failure raised, got unknown=%v err=%v", unknown, err)
+	}
+}
+
+// A plaintext address is not resolved at all: user search sees only emails made
+// public on a profile, so it answers for a minority and costs the strictest rate
+// limit we touch. It reaches the contributor through the report, not as a fault.
+func TestResolveCoauthorsReportsAPlaintextAddress(t *testing.T) {
 	commits := []Commit{commit("a1", user("alice", 1), user("alice", 1),
 		"feat: thing\n\nCo-authored-by: Carol <carol@example.com>\n")}
 
-	c := newChecker(&fakeGitHub{lookupErr: errors.New("403 rate limit exceeded")}, &bytes.Buffer{})
-	found, unresolved := c.resolveCoauthors(t.Context(), commits)
-	if len(found) != 0 || len(unresolved) != 1 || unresolved[0] != "carol@example.com" {
-		t.Fatalf("want carol unresolved, got found=%v unresolved=%v", found, unresolved)
+	c := newChecker(&fakeGitHub{}, &bytes.Buffer{})
+	found, unknown, err := c.resolveCoauthors(t.Context(), commits)
+	if err != nil || len(found) != 0 || len(unknown) != 1 || unknown[0] != "carol@example.com" {
+		t.Fatalf("want the address reported, got found=%v unknown=%v err=%v", found, unknown, err)
+	}
+}
+
+// An assistant holds no copyright, so its trailer is skipped rather than blocking
+// — otherwise every contributor using one rewrites their branch to merge. The
+// pairing matters: an address that might belong to a person must still stop the
+// gate, or the exemption is a hole rather than a rule.
+func TestAnAssistantTrailerIsSkippedButAPersonsIsNot(t *testing.T) {
+	msg := "feat: thing\n\nCo-authored-by: Claude <noreply@anthropic.com>\n"
+	c := newChecker(&fakeGitHub{}, &bytes.Buffer{})
+	found, unknown, err := c.resolveCoauthors(t.Context(),
+		[]Commit{commit("a1", user("alice", 1), user("alice", 1), msg)})
+	if err != nil || len(found) != 0 || len(unknown) != 0 {
+		t.Fatalf("an assistant licenses nothing and must not block, got found=%v unknown=%v err=%v", found, unknown, err)
+	}
+
+	person := "feat: thing\n\nCo-authored-by: Carol <carol@anthropic.com>\n"
+	_, unknown, err = c.resolveCoauthors(t.Context(),
+		[]Commit{commit("a1", user("alice", 1), user("alice", 1), person)})
+	if err != nil || len(unknown) != 1 {
+		t.Fatalf("a colleague at the same domain still holds copyright, got unknown=%v err=%v", unknown, err)
+	}
+}
+
+// The gate still blocks — a trailer names a copyright holder either way — but the
+// contributor must meet the ordinary report, not an error that hides it.
+func TestUnidentifiedCoauthorBlocksThroughTheReport(t *testing.T) {
+	var out bytes.Buffer
+	gh := &fakeGitHub{
+		files: map[string]*SignatureFile{"head": file(sig("alice", 1)), "base": file(sig("alice", 1))},
+		commits: []Commit{commit("a1", user("alice", 1), user("alice", 1),
+			"feat\n\nCo-authored-by: Carol <carol@example.com>\n")},
+	}
+	c := newChecker(gh, &out)
+
+	if err := c.check(t.Context()); !errors.Is(err, errUnsigned) {
+		t.Fatalf("want errUnsigned, got %v", err)
+	}
+	for _, want := range []string{"::error::", "carol@example.com", "drop the trailer"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("want %q in the report, got %q", want, out.String())
+		}
+	}
+	if len(gh.posted) != 1 || !strings.Contains(gh.posted[0].Body, "carol@example.com") {
+		t.Errorf("want the address in the comment too, got %+v", gh.posted)
 	}
 }
 
@@ -231,9 +284,9 @@ func TestResolveCoauthorsFallsBackToTheAPIForTheIDLessNoreplyForm(t *testing.T) 
 		"feat: thing\n\nCo-authored-by: Bob <bob@users.noreply.github.com>\n")}
 
 	c := newChecker(&fakeGitHub{byLogin: map[string]Principal{"bob": {ID: 99, Login: "bob", Type: "User"}}}, &bytes.Buffer{})
-	found, unresolved := c.resolveCoauthors(t.Context(), commits)
-	if len(unresolved) != 0 || len(found) != 1 || found[0].ID != 99 {
-		t.Fatalf("want bob resolved to id 99, got found=%v unresolved=%v", found, unresolved)
+	found, unknown, err := c.resolveCoauthors(t.Context(), commits)
+	if err != nil || len(unknown) != 0 || len(found) != 1 || found[0].ID != 99 {
+		t.Fatalf("want bob resolved to id 99, got found=%v unknown=%v err=%v", found, unknown, err)
 	}
 }
 
@@ -281,6 +334,12 @@ func TestLoadConfigRejectsInputsItCannotCheckWithout(t *testing.T) {
 		{"no opener", map[string]string{"PR_USER_ID": ""}, "PR_USER_ID"},
 		{"no repo", map[string]string{"GITHUB_REPOSITORY": ""}, "GITHUB_REPOSITORY is empty"},
 		{"no head", map[string]string{"PR_HEAD_SHA": ""}, "PR_HEAD_SHA is empty"},
+		// "0" parses, so only the explicit guard catches it — and an id of zero is
+		// dropped by unsigned(), which would empty the check rather than fail it.
+		{"zero opener", map[string]string{"PR_USER_ID": "0"}, "PR_USER_ID is zero"},
+		// appendOnly matches the entry's login against the opener's, so an empty
+		// one refuses every signature the report hands out.
+		{"no opener login", map[string]string{"PR_USER_LOGIN": ""}, "PR_USER_LOGIN is empty"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -313,7 +372,7 @@ func TestForgedCoauthorTrailerCannotSignForAStranger(t *testing.T) {
 	var out bytes.Buffer
 	c := newChecker(&fakeGitHub{
 		files: map[string]*SignatureFile{
-			"head": file(sig("mallory", 2), Signature{Login: "victim", ID: 42, Name: "V", Date: "2026-08-30", CLA: "v1"}),
+			"head": file(sig("mallory", 2), Signature{Login: "victim", ID: 42, Date: "2026-08-30", CLA: "v1"}),
 			"base": file(sig("mallory", 2)),
 		},
 		commits: []Commit{commit("a1", user("mallory", 2), user("mallory", 2),
@@ -323,12 +382,54 @@ func TestForgedCoauthorTrailerCannotSignForAStranger(t *testing.T) {
 	c.cfg.opener = Principal{ID: 2, Login: "mallory", Type: "User"}
 
 	err := c.check(t.Context())
-	if err == nil || !strings.Contains(err.Error(), "you may only sign for yourself") {
+	if !errors.Is(err, errUnsigned) || !strings.Contains(out.String(), "you may only sign for yourself") {
 		t.Fatalf("want the stranger signature rejected, got %v (out=%q)", err, out.String())
 	}
 }
 
-// An id-less or malformed co-author must be reported, not silently skipped:
+// The trailer above named a login that resolves to nobody. Naming a real one is
+// the sharper attack: the id then comes back from the API and is genuinely the
+// victim's, so only refusing every signature but the opener's stops it.
+func TestNamingARealCoauthorStillCannotSignForThem(t *testing.T) {
+	var out bytes.Buffer
+	c := newChecker(&fakeGitHub{
+		files: map[string]*SignatureFile{
+			"head": file(sig("mallory", 2), sig("victim", 777)),
+			"base": file(sig("mallory", 2)),
+		},
+		commits: []Commit{commit("a1", user("mallory", 2), user("mallory", 2),
+			"feat\n\nCo-authored-by: Victim <victim@users.noreply.github.com>\n")},
+		byLogin: map[string]Principal{"victim": {ID: 777, Login: "victim", Type: "User"}},
+	}, &out)
+	c.cfg.opener = Principal{ID: 2, Login: "mallory", Type: "User"}
+
+	err := c.check(t.Context())
+	if !errors.Is(err, errUnsigned) || !strings.Contains(out.String(), "who did not open it") {
+		t.Fatalf("want the stranger signature rejected, got %v (out=%q)", err, out.String())
+	}
+}
+
+// `git commit --author=` is free to set, so GitHub attributes the commit to
+// whoever the address belongs to. That made the commit author a second way to
+// name a victim as a principal and then sign for them.
+func TestForgedCommitAuthorCannotSignForAStranger(t *testing.T) {
+	var out bytes.Buffer
+	c := newChecker(&fakeGitHub{
+		files: map[string]*SignatureFile{
+			"head": file(sig("mallory", 2), sig("victim", 777)),
+			"base": file(sig("mallory", 2)),
+		},
+		commits: []Commit{commit("a1", user("victim", 777), user("mallory", 2), "feat")},
+	}, &out)
+	c.cfg.opener = Principal{ID: 2, Login: "mallory", Type: "User"}
+
+	err := c.check(t.Context())
+	if !errors.Is(err, errUnsigned) || !strings.Contains(out.String(), "who did not open it") {
+		t.Fatalf("want the stranger signature rejected, got %v (out=%q)", err, out.String())
+	}
+}
+
+// The noreply form resolving to nobody must block, not be silently skipped:
 // dropping it let the gate pass while never checking that person at all.
 func TestUnresolvableCoauthorIsReported(t *testing.T) {
 	var out bytes.Buffer
@@ -339,9 +440,11 @@ func TestUnresolvableCoauthorIsReported(t *testing.T) {
 	}, &out)
 	c.cfg.opener = Principal{ID: 2, Login: "mallory", Type: "User"}
 
-	err := c.check(t.Context())
-	if err == nil || !strings.Contains(err.Error(), "did not resolve") {
-		t.Fatalf("want the co-author reported, got %v (out=%q)", err, out.String())
+	if err := c.check(t.Context()); !errors.Is(err, errUnsigned) {
+		t.Fatalf("want the co-author to block the gate, got %v (out=%q)", err, out.String())
+	}
+	if !strings.Contains(out.String(), "0+realperson@users.noreply.github.com") {
+		t.Fatalf("want the address named in the report, got %q", out.String())
 	}
 }
 
@@ -394,10 +497,10 @@ func TestStaleBranchIsNotAccusedOfDeletingASignature(t *testing.T) {
 // let one invalidate everyone's signature at once.
 func TestPullRequestCannotChangeTheCLAVersion(t *testing.T) {
 	head := &SignatureFile{CLAVersion: "v2", Signatures: []Signature{
-		{Login: "alice", ID: 1, Name: "A", Date: "2026-01-01", CLA: "v1"},
+		{Login: "alice", ID: 1, Date: "2026-01-01", CLA: "v1"},
 	}}
-	err := appendOnly(file(sig("alice", 1)), head, map[int64]bool{1: true})
-	if err == nil || !strings.Contains(err.Error(), "changes cla_version") {
+	err := appendOnly(file(sig("alice", 1)), head, Principal{ID: 1, Login: "alice", Type: "User"}, "v1")
+	if err == nil || !strings.Contains(err.Error(), "cla_version is") {
 		t.Fatalf("want the version change rejected, got %v", err)
 	}
 }
@@ -405,7 +508,7 @@ func TestPullRequestCannotChangeTheCLAVersion(t *testing.T) {
 // A login is contributor-controlled text out of signatures/cla.json. Emitted raw,
 // a newline in one starts a second workflow command on the line below it.
 func TestAnnotationEscapingKeepsAnErrorToOneCommand(t *testing.T) {
-	f := file(Signature{Login: "a\n::error::injected", ID: 1, Name: "N", Date: "bad", CLA: "v1"})
+	f := file(Signature{Login: "a\n::error::injected", ID: 1, Date: "bad", CLA: "v1"})
 	err := f.validate()
 	if err == nil {
 		t.Fatal("want a validation error to carry the login")
@@ -443,7 +546,7 @@ func TestCheckCommentsMentioningTheUnsignedContributor(t *testing.T) {
 	if len(gh.posted) != 1 {
 		t.Fatalf("want one comment, got %d", len(gh.posted))
 	}
-	for _, want := range []string{commentMarker, "@alice", `"id": 1`} {
+	for _, want := range []string{commentMarker, "@alice", `"id":    1`} {
 		if !strings.Contains(gh.posted[0].Body, want) {
 			t.Fatalf("want %q in the comment, got %q", want, gh.posted[0].Body)
 		}
@@ -578,10 +681,10 @@ func TestCheckIgnoresAQuotedMarker(t *testing.T) {
 // A gate that fell over must not leave "signed" standing on a red check, nor
 // repeat advice the contributor has just followed and failed on.
 func TestCheckReplacesItsCommentWhenTheGateCannotFinish(t *testing.T) {
-	// mallory signed but authored nothing here, so appendOnly rejects the file.
+	// No file at the head sha: the gate cannot read what it is meant to judge.
 	forged := func() *fakeGitHub {
 		return &fakeGitHub{
-			files:   map[string]*SignatureFile{"head": file(sig("mallory", 99)), "base": file()},
+			files:   map[string]*SignatureFile{"base": file()},
 			commits: []Commit{commit("a1", user("alice", 1), user("alice", 1), "x")},
 		}
 	}
@@ -589,7 +692,7 @@ func TestCheckReplacesItsCommentWhenTheGateCannotFinish(t *testing.T) {
 	gh := forged()
 	gh.posted = []Comment{{ID: 9, Body: signedComment("v1")}}
 	if err := newChecker(gh, &bytes.Buffer{}).check(t.Context()); err == nil || errors.Is(err, errUnsigned) {
-		t.Fatalf("want an append-only failure, got %v", err)
+		t.Fatalf("want a checker fault, got %v", err)
 	}
 	if gh.edits != 1 || strings.Contains(gh.posted[0].Body, "signed") {
 		t.Fatalf("want the signed note replaced, got %q after %d edits", gh.posted[0].Body, gh.edits)
@@ -598,7 +701,7 @@ func TestCheckReplacesItsCommentWhenTheGateCannotFinish(t *testing.T) {
 	// Nothing standing means nothing to correct; a bare failure is not worth a comment.
 	quiet := forged()
 	if err := newChecker(quiet, &bytes.Buffer{}).check(t.Context()); err == nil {
-		t.Fatal("want an append-only failure")
+		t.Fatal("want a checker fault")
 	}
 	if len(quiet.posted) != 0 {
 		t.Fatalf("want no comment, got %+v", quiet.posted)
@@ -639,12 +742,12 @@ func TestCheckLabelsEachOutcome(t *testing.T) {
 	// A gate that could not finish knows nothing, but must not leave "signed"
 	// standing on a red check.
 	broken := &fakeGitHub{
-		files:    map[string]*SignatureFile{"head": file(sig("mallory", 99)), "base": file()},
+		files:    map[string]*SignatureFile{"base": file()},
 		commits:  []Commit{commit("a1", user("alice", 1), user("alice", 1), "x")},
 		labelled: []string{labelSigned},
 	}
 	if err := newChecker(broken, &bytes.Buffer{}).check(t.Context()); err == nil || errors.Is(err, errUnsigned) {
-		t.Fatalf("want an append-only failure, got %v", err)
+		t.Fatalf("want a checker fault, got %v", err)
 	}
 	if len(broken.labelled) != 0 {
 		t.Fatalf("want the signed label dropped, got %v", broken.labelled)
@@ -664,5 +767,72 @@ func TestCheckDoesNotRewriteACorrectLabel(t *testing.T) {
 	}
 	if gh.labelWrites != 0 {
 		t.Fatalf("want no label write, got %d", gh.labelWrites)
+	}
+}
+
+// The signature file is absent at the merge base only if the read failed, now
+// that it exists on the base branch. Treating that as an empty history disarmed
+// both append-only guards, so a pull request could name its own cla_version.
+func TestAMissingBaseFileIsAFailureNotAnEmptyHistory(t *testing.T) {
+	var out bytes.Buffer
+	c := newChecker(&fakeGitHub{
+		base: "mergebase", // no file there
+		files: map[string]*SignatureFile{
+			"base": file(),
+			"head": {CLAVersion: "vBOGUS", Signatures: []Signature{
+				{Login: "mallory", ID: 7, Date: "2026-08-30", CLA: "vBOGUS"}}},
+		},
+		commits: []Commit{commit("a1", user("mallory", 7), user("mallory", 7), "feat")},
+	}, &out)
+	c.cfg.opener = Principal{ID: 7, Login: "mallory", Type: "User"}
+
+	err := c.check(t.Context())
+	if err == nil || errors.Is(err, errUnsigned) {
+		t.Fatalf("want a read failure, not a verdict, got %v (out=%q)", err, out.String())
+	}
+	if strings.Contains(out.String(), "verified") {
+		t.Fatalf("a self-declared cla_version must never read as verified, got %q", out.String())
+	}
+}
+
+// A rejected edit is the contributor's to fix, so it takes the unsigned label and
+// a comment rather than reading as a gate that fell over.
+func TestARejectedEditIsReportedLikeAnUnsignedCLA(t *testing.T) {
+	var out bytes.Buffer
+	gh := &fakeGitHub{
+		files: map[string]*SignatureFile{
+			"head": file(sig("mallory", 2), sig("victim", 777)),
+			"base": file(sig("mallory", 2)),
+		},
+		commits:  []Commit{commit("a1", user("mallory", 2), user("mallory", 2), "feat")},
+		labelled: []string{labelSigned},
+	}
+	c := newChecker(gh, &out)
+	c.cfg.opener = Principal{ID: 2, Login: "mallory", Type: "User"}
+
+	if err := c.check(t.Context()); !errors.Is(err, errUnsigned) {
+		t.Fatalf("want errUnsigned, got %v", err)
+	}
+	if !slices.Equal(gh.labelled, []string{labelUnsigned}) {
+		t.Fatalf("want the not-signed label, got %v", gh.labelled)
+	}
+	if len(gh.posted) != 1 || !strings.Contains(gh.posted[0].Body, "was rejected") {
+		t.Fatalf("want a comment naming the rejection, got %v", gh.posted)
+	}
+}
+
+// An assistant trailer names no copyright holder, so a pull request carrying one
+// and nothing else must go green without a history rewrite.
+func TestAnAssistantTrailerAloneDoesNotBlockTheGate(t *testing.T) {
+	for _, addr := range []string{"noreply@anthropic.com", "NoReply@Anthropic.COM"} {
+		var out bytes.Buffer
+		c := newChecker(&fakeGitHub{
+			files: map[string]*SignatureFile{"head": file(sig("alice", 1)), "base": file(sig("alice", 1))},
+			commits: []Commit{commit("a1", user("alice", 1), user("alice", 1),
+				"feat\n\nCo-authored-by: Claude <"+addr+">\n")},
+		}, &out)
+		if err := c.check(t.Context()); err != nil {
+			t.Fatalf("%s must not block: %v (out=%q)", addr, err, out.String())
+		}
 	}
 }

--- a/tools/clacheck/report.go
+++ b/tools/clacheck/report.go
@@ -1,16 +1,10 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 )
-
-// placeholderName is what entryJSON hands out and what validate refuses back:
-// a signature under it records agreement by nobody.
-const placeholderName = "Your Name"
 
 type report struct {
 	text     string // job log, plus the ::error:: annotation shown on the checks page
@@ -25,111 +19,144 @@ const commentMarker = "<!-- clacheck:signature-request -->"
 func entryJSON(p Principal, version, indent string, now time.Time) string {
 	return fmt.Sprintf(`%s{ "login": %q,
 %s  "id":    %d,
-%s  "name":  %q,
 %s  "date":  %q,
 %s  "cla":   %q }`,
-		indent, p.Login, indent, p.ID, indent, placeholderName, indent, now.UTC().Format(time.DateOnly), indent, version)
+		indent, p.Login, indent, p.ID, indent, now.UTC().Format(time.DateOnly), indent, version)
 }
 
 // unsignedReport is what a contributor actually meets when the gate fails. It
 // carries their entry already filled in, so signing is a copy and a commit rather
 // than a hunt through documentation for a numeric id they have never needed.
-func unsignedReport(cfg config, head *SignatureFile, missing []Principal, now time.Time) report {
-	version := head.CLAVersion
-	logins := make([]string, len(missing))
-	for i, p := range missing {
-		logins[i] = p.Login
-	}
+//
+// Only the opener's entry is offered: appendOnly accepts no other, so printing one
+// for a co-author would be advice that fails on the next run.
+func unsignedReport(cfg config, head *SignatureFile, missing []Principal, unknown []string, now time.Time) report {
+	mine, others := splitByOpener(missing, cfg.opener.ID)
 	claURL := fmt.Sprintf("%s/%s/blob/%s/CLA.md", cfg.serverURL, cfg.repo, cfg.baseRef)
-	entries := plural(len(missing), "this entry", "these entries")
+	named := append(loginsOf(missing), unknown...)
 
 	var text strings.Builder
-	fmt.Fprintf(&text, "::error::CLA %s not signed by: %s\n", version, strings.Join(logins, ", "))
-	fmt.Fprintf(&text, "\nThanks for the contribution! One thing before this can merge.\n\n")
-	fmt.Fprintf(&text, "Read the agreement: %s\n\n", claURL)
-	fmt.Fprintf(&text, "If you agree, add %s to signatures/cla.json in this pull request:\n\n", entries)
-	for _, p := range missing {
-		fmt.Fprintf(&text, "%s\n\n", entryJSON(p, version, "  ", now))
+	// The names carry a trailer address, which is the pull request's to choose, so
+	// the annotation is encoded: a bare %0A in one would start a second command.
+	fmt.Fprintf(&text, "::error::CLA %s not signed by: %s\n", head.CLAVersion, escapeAnnotation(strings.Join(named, ", ")))
+	fmt.Fprintf(&text, "\nThe agreement: %s\n", claURL)
+	if mine != nil {
+		fmt.Fprintf(&text, "\nAdd this entry to signatures/cla.json, then commit and push — that\n")
+		fmt.Fprintf(&text, "commit is your signature:\n\n")
+		fmt.Fprintf(&text, "%s\n", entryJSON(*mine, head.CLAVersion, "  ", now))
 	}
-	fmt.Fprintf(&text, "Replace %q with your own name, then commit it and push — that commit is\n", placeholderName)
-	fmt.Fprintf(&text, "your signature. You only do it once per CLA version.\n")
+	for _, b := range trailerBlocks(others, unknown, verbatim) {
+		fmt.Fprintf(&text, "\n%s\n", b)
+	}
 
-	whole, ok := signedFile(head, missing, now)
+	marked := trailerBlocks(others, unknown, mdCode)
 	return report{
 		text:     text.String(),
-		markdown: signMarkdown(claURL, head, missing, now, whole, ok, 0),
-		comment:  commentMarker + "\n" + signMarkdown(claURL, head, missing, now, whole, ok, cfg.opener.ID),
+		markdown: signMarkdown(claURL, head, mine, marked, now, false),
+		comment:  commentMarker + "\n" + signMarkdown(claURL, head, mine, marked, now, true),
 	}
 }
 
-// Only mentionID is mentioned: every other login can be invented by a
-// Co-authored-by trailer, which would let a pull request notify anyone it names.
-func signMarkdown(claURL string, head *SignatureFile, missing []Principal, now time.Time, whole string, wholeFits bool, mentionID int64) string {
-	version := head.CLAVersion
-	named := make([]string, len(missing))
+// A trailer address is whatever the commit message said, so it reaches markdown
+// only inside a code span, which renders it literally. The backtick that would
+// end the span early is dropped rather than escaped: an address has no use for
+// one, and a half-escaped span is worse than a missing character.
+func mdCode(s string) string { return "`" + strings.ReplaceAll(s, "`", "") + "`" }
+
+func verbatim(s string) string { return s }
+
+// appendOnly will not take a co-author's signature from this pull request, and an
+// assistant holds no copyright to license, so each block has to name the way out
+// or the gate is red with none. quote renders the trailer address for whichever
+// surface the blocks are bound for; a login needs none of it, since it comes back
+// from the API rather than out of the commit.
+func trailerBlocks(others []Principal, unknown []string, quote func(string) string) []string {
+	var out []string
+	if n := len(others); n > 0 {
+		verb := "has work in this pull request and has not signed"
+		if n > 1 {
+			verb = "have work in this pull request and have not signed"
+		}
+		out = append(out, joinNames(loginsOf(others))+" "+verb+
+			". Everyone signs in a pull request they opened themselves, so this one cannot sign for them.")
+	}
+	if n := len(unknown); n > 0 {
+		quoted := make([]string, n)
+		for i, u := range unknown {
+			quoted[i] = quote(u)
+		}
+		lead := "A Co-authored-by trailer names "
+		if n > 1 {
+			lead = "Co-authored-by trailers name "
+		}
+		// The address never opens the line: one starting "::" is a workflow
+		// command, and this line goes to the log as well.
+		out = append(out, lead+joinNames(quoted)+
+			", which the check cannot identify. Use the "+quote("<id>+<login>@users.noreply.github.com")+
+			" address GitHub writes itself, or drop the trailer if it names an assistant.")
+	}
+	return out
+}
+
+// joinNames renders a list into the sentence around it: "a", "a and b",
+// "a, b and c".
+func joinNames(names []string) string {
+	switch len(names) {
+	case 0:
+		return ""
+	case 1:
+		return names[0]
+	case 2:
+		return names[0] + " and " + names[1]
+	}
+	return strings.Join(names[:len(names)-1], ", ") + " and " + names[len(names)-1]
+}
+
+func loginsOf(ps []Principal) []string {
+	out := make([]string, len(ps))
+	for i, p := range ps {
+		out[i] = p.Login
+	}
+	return out
+}
+
+func splitByOpener(missing []Principal, openerID int64) (mine *Principal, others []Principal) {
 	for i, p := range missing {
-		if named[i] = p.Login; p.ID == mentionID {
-			named[i] = "@" + p.Login
+		if p.ID == openerID {
+			mine = &missing[i]
+			continue
 		}
+		others = append(others, p)
 	}
-	entries := plural(len(missing), "this entry", "these entries")
-
-	var md strings.Builder
-	fmt.Fprintf(&md, "## Signature required\n\n")
-	fmt.Fprintf(&md, "Thanks for contributing! Before this can merge, everyone whose work is in this "+
-		"pull request needs to have signed the [Contributor License Agreement](%s).\n\n", claURL)
-	fmt.Fprintf(&md, "**Not signed yet:** %s\n\n", strings.Join(named, ", "))
-	fmt.Fprintf(&md, "### How to sign\n\n")
-	if wholeFits {
-		fmt.Fprintf(&md, "Copy this over the whole of `signatures/cla.json`, replacing `%s` with your own:\n\n", placeholderName)
-		fmt.Fprintf(&md, "```json\n%s```\n\n", whole)
-	} else {
-		fmt.Fprintf(&md, "Add %s to the `signatures` array in `signatures/cla.json`, %s:\n\n", entries,
-			plural(len(missing), "replacing `"+placeholderName+"` with your own name",
-				"replacing each `"+placeholderName+"` with that person's own name"))
-		fmt.Fprintf(&md, "```json\n")
-		for i, p := range missing {
-			if i > 0 {
-				md.WriteString(",\n")
-			}
-			md.WriteString(entryJSON(p, version, "", now))
-		}
-		fmt.Fprintf(&md, "\n```\n\n")
-	}
-	fmt.Fprintf(&md, "Commit that to this pull request and push. Your id is already filled in above — "+
-		"it identifies you even if you later change your username.\n\n")
-	fmt.Fprintf(&md, "You sign **once** per CLA version. It covers everything you contribute here afterwards.\n")
-
-	return md.String()
+	return mine, others
 }
 
-// fullFileMaxSignatures caps the paste-the-whole-file form. Past it the comment
-// would be longer than the change it asks for, so the entry is shown alone.
-const fullFileMaxSignatures = 20
-
-// Existing entries are reproduced verbatim, so pasting it is append-only. Single
-// signer only: of two placeholders, whoever pastes fills in one and validate
-// rejects the other on the next run.
-func signedFile(head *SignatureFile, missing []Principal, now time.Time) (string, bool) {
-	if len(missing) != 1 || len(head.Signatures) > fullFileMaxSignatures {
-		return "", false
+// Only the opener is mentioned: every other login can be invented by a
+// Co-authored-by trailer, which would let a pull request notify anyone it names.
+func signMarkdown(claURL string, head *SignatureFile, mine *Principal, blocks []string, now time.Time, mention bool) string {
+	var md strings.Builder
+	// The comment notifies the opener. With nothing for them to sign, a heading
+	// demanding their signature reads as a demand they have already met.
+	heading, tail := "## CLA signature required", ""
+	if mine == nil {
+		heading, tail = "## CLA check blocked", " Still outstanding:"
 	}
-	out := *head
-	out.Signatures = slices.Clone(head.Signatures)
-	for _, p := range missing {
-		out.Signatures = append(out.Signatures, Signature{
-			Login: p.Login,
-			ID:    p.ID,
-			Name:  placeholderName,
-			Date:  now.UTC().Format(time.DateOnly),
-			CLA:   head.CLAVersion,
-		})
+	fmt.Fprintf(&md, "%s\n\n", heading)
+	fmt.Fprintf(&md, "Thanks for contributing! Everyone with work in this pull request has to "+
+		"sign the [Contributor License Agreement](%s) before it can merge.%s\n", claURL, tail)
+	if mine != nil {
+		name := mine.Login
+		if mention {
+			name = "@" + name
+		}
+		fmt.Fprintf(&md, "\n**%s** — add this to the `signatures` array in `signatures/cla.json`, "+
+			"then commit and push. That commit is your signature.\n\n```json\n%s\n```\n",
+			name, entryJSON(*mine, head.CLAVersion, "", now))
 	}
-	b, err := json.MarshalIndent(out, "", "  ")
-	if err != nil {
-		return "", false
+	for _, b := range blocks {
+		fmt.Fprintf(&md, "\n%s\n", b)
 	}
-	return string(b) + "\n", true
+	return md.String()
 }
 
 // The gate's two labels. They are mutually exclusive, so setting one clears the
@@ -145,15 +172,14 @@ func signedComment(version string) string {
 	return fmt.Sprintf("%s\nCLA %s signed — thanks!\n", commentMarker, version)
 }
 
+// Like problemComment, the reason stays in the log: it quotes a login out of the
+// pull request's own file. The comment only has to get the contributor there.
+func rejectedComment() string {
+	return commentMarker + "\nThe change to `signatures/cla.json` was rejected. See the job log on the checks tab for what to fix.\n"
+}
+
 // The error itself is left to the log: it can quote a login out of the pull
 // request's own file, which would break out of any markup used here.
 func problemComment() string {
 	return commentMarker + "\nThe CLA check did not finish. See the job log on the checks tab for what went wrong.\n"
-}
-
-func plural(n int, one, many string) string {
-	if n == 1 {
-		return one
-	}
-	return many
 }

--- a/tools/clacheck/report_test.go
+++ b/tools/clacheck/report_test.go
@@ -2,17 +2,20 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
+	"slices"
 	"strings"
 	"testing"
 )
 
+// carol opens every report test: the entry the report hands out is the opener's,
+// because appendOnly will not accept anyone else's.
 func reportCfg() config {
-	return config{repo: "pug-sh/pug", baseRef: "main", serverURL: "https://github.com"}
+	return config{repo: "pug-sh/pug", baseRef: "main", serverURL: "https://github.com",
+		opener: Principal{ID: 42, Login: "carol", Type: "User"}}
 }
 
 func TestUnsignedReportFillsInTheContributorsEntry(t *testing.T) {
-	r := unsignedReport(reportCfg(), file(), []Principal{{ID: 42, Login: "carol", Type: "User"}}, fixedNow)
+	r := unsignedReport(reportCfg(), file(), []Principal{{ID: 42, Login: "carol", Type: "User"}}, nil, fixedNow)
 
 	if !strings.HasPrefix(r.text, "::error::CLA v1 not signed by: carol\n") {
 		t.Fatalf("the annotation must be the first line, got %q", r.text)
@@ -22,9 +25,7 @@ func TestUnsignedReportFillsInTheContributorsEntry(t *testing.T) {
 			t.Errorf("want %q in the log report", want)
 		}
 	}
-	// The summary carries the file as it should be committed, so it is marshaled
-	// rather than aligned by hand.
-	for _, want := range []string{`"login": "carol"`, `"id": 42`, `"date": "2026-08-30"`, `"cla": "v1"`} {
+	for _, want := range []string{`"login": "carol"`, `"id":    42`, `"date":  "2026-08-30"`, `"cla":   "v1"`} {
 		if !strings.Contains(r.markdown, want) {
 			t.Errorf("want %q in the job summary", want)
 		}
@@ -35,41 +36,40 @@ func TestUnsignedReportFillsInTheContributorsEntry(t *testing.T) {
 	}
 }
 
-// The code block is meant to replace signatures/cla.json outright, so it has to
-// parse as that whole file — not merely look like JSON.
-func TestUnsignedReportEmitsPasteableJSON(t *testing.T) {
-	r := unsignedReport(reportCfg(), file(), []Principal{{ID: 42, Login: "carol", Type: "User"}}, fixedNow)
+// The block is one entry for the contributor to append, so it has to parse as a
+// signature — and appending it must be the whole of what the gate wants back.
+func TestUnsignedReportEmitsAnAppendableEntry(t *testing.T) {
+	head := file(sig("alice", 1))
+	r := unsignedReport(reportCfg(), head, []Principal{{ID: 42, Login: "carol", Type: "User"}}, nil, fixedNow)
 
-	_, block, ok := strings.Cut(r.markdown, "```json\n")
+	_, block, ok := strings.Cut(r.comment, "```json\n")
 	if !ok {
-		t.Fatalf("want a json block in the summary, got %q", r.markdown)
+		t.Fatalf("want a json block in the comment, got %q", r.comment)
 	}
 	block, _, ok = strings.Cut(block, "```")
 	if !ok {
-		t.Fatalf("want the json block to be closed, got %q", r.markdown)
+		t.Fatalf("want the json block to be closed, got %q", r.comment)
 	}
 
-	var pasted SignatureFile
-	if err := json.Unmarshal([]byte(block), &pasted); err != nil {
-		t.Fatalf("the block is not a usable signatures/cla.json: %v\n%s", err, block)
+	var entry Signature
+	if err := json.Unmarshal([]byte(block), &entry); err != nil {
+		t.Fatalf("the block is not a usable signatures entry: %v\n%s", err, block)
 	}
-	entries := pasted.Signatures
-	if len(entries) != 1 || entries[0].ID != 42 {
-		t.Fatalf("want carol's entry with her id, got %+v", entries)
+	if entry.ID != 42 || entry.Login != "carol" {
+		t.Fatalf("want carol's entry with her id, got %+v", entry)
 	}
-	for _, e := range entries {
-		if e.Name != "Your Name" || e.CLA != "v1" || e.Date != "2026-08-30" {
-			t.Fatalf("entry is not ready to edit and commit: %+v", e)
-		}
+	if entry.CLA != "v1" || entry.Date != "2026-08-30" {
+		t.Fatalf("want the version in force and the current date, got %+v", entry)
 	}
-}
 
-func TestPlural(t *testing.T) {
-	if got := plural(1, "this entry", "these entries"); got != "this entry" {
-		t.Fatalf("want the singular, got %q", got)
+	// Appending it and changing nothing else is the whole of the instruction, so
+	// it has to be the whole of what the gate asks for.
+	signed := file(append(slices.Clone(head.Signatures), entry)...)
+	if err := signed.validate(); err != nil {
+		t.Fatalf("the appended file must pass as it stands: %v", err)
 	}
-	if got := plural(2, "this entry", "these entries"); got != "these entries" {
-		t.Fatalf("want the plural, got %q", got)
+	if err := appendOnly(head, signed, reportCfg().opener, "v1"); err != nil {
+		t.Fatalf("following the instructions must satisfy the gate: %v", err)
 	}
 }
 
@@ -82,7 +82,7 @@ func TestOnlyTheOpenerIsMentioned(t *testing.T) {
 	r := unsignedReport(cfg, file(), []Principal{
 		{ID: 42, Login: "carol", Type: "User"},
 		{ID: 7, Login: "torvalds", Type: "User"},
-	}, fixedNow)
+	}, nil, fixedNow)
 
 	if !strings.Contains(r.comment, "@carol") {
 		t.Errorf("the comment must mention the opener, got %q", r.comment)
@@ -101,90 +101,118 @@ func TestOnlyTheOpenerIsMentioned(t *testing.T) {
 	}
 }
 
-// Pasting the block must not cost anyone their signature: the whole-file form
-// reproduces the entries already there, which is what appendOnly demands back.
-func TestWholeFileFormKeepsExistingSignatures(t *testing.T) {
-	head := file(sig("alice", 1))
-	head.Comment = "append-only"
-	r := unsignedReport(reportCfg(), head, []Principal{{ID: 42, Login: "carol", Type: "User"}}, fixedNow)
-
-	_, block, _ := strings.Cut(r.comment, "```json\n")
-	block, _, _ = strings.Cut(block, "```")
-
-	var pasted SignatureFile
-	if err := json.Unmarshal([]byte(block), &pasted); err != nil {
-		t.Fatalf("the block is not a usable signatures/cla.json: %v", err)
-	}
-	if pasted.Comment != head.Comment || pasted.CLAVersion != "v1" {
-		t.Fatalf("want the file's own fields carried over, got %+v", pasted)
-	}
-	if len(pasted.Signatures) != 2 || pasted.Signatures[0] != head.Signatures[0] {
-		t.Fatalf("want alice reproduced verbatim and carol appended, got %+v", pasted.Signatures)
-	}
-	// The one edit left to the contributor is their name; everything else the
-	// gate will accept as it stands.
-	if err := pasted.validate(); err == nil || !strings.Contains(err.Error(), "placeholder") {
-		t.Fatalf("want the placeholder to be the only thing left to fix, got %v", err)
-	}
-	pasted.Signatures[1].Name = "Carol Danvers"
-	if err := pasted.validate(); err != nil {
-		t.Fatalf("the pasted file must pass once named: %v", err)
-	}
-	if err := appendOnly(head, &pasted, map[int64]bool{42: true}); err != nil {
-		t.Fatalf("following the instructions must satisfy the gate: %v", err)
-	}
-}
-
-// The two forms are told apart by what the block parses as, not by the prose
-// above it: reword that sentence and a phrasing assertion passes vacuously.
-func wholeFileForm(t *testing.T, comment string) bool {
-	t.Helper()
-	_, block, ok := strings.Cut(comment, "```json\n")
-	if !ok {
-		t.Fatalf("want a json block, got %q", comment)
-	}
-	block, _, _ = strings.Cut(block, "```")
-	var f SignatureFile
-	return json.Unmarshal([]byte(block), &f) == nil && f.CLAVersion != ""
-}
-
-// A file past the cap falls back to the entry alone: a comment reproducing every
-// existing signature buries the one line the contributor has to add.
-func TestLongSignatureFileFallsBackToTheEntryForm(t *testing.T) {
-	long, atCap := file(), file()
-	for i := range fullFileMaxSignatures + 1 {
-		long.Signatures = append(long.Signatures, sig(fmt.Sprintf("dev%d", i), int64(i+100)))
-		if i < fullFileMaxSignatures {
-			atCap.Signatures = append(atCap.Signatures, sig(fmt.Sprintf("dev%d", i), int64(i+100)))
-		}
-	}
-	carol := []Principal{{ID: 42, Login: "carol", Type: "User"}}
-
-	r := unsignedReport(reportCfg(), long, carol, fixedNow)
-	if wholeFileForm(t, r.comment) {
-		t.Fatalf("want the entry form past the cap, got %q", r.comment)
-	}
-	if !strings.Contains(r.comment, `"id":    42`) {
-		t.Fatalf("want carol's entry to append, got %q", r.comment)
-	}
-	// The cap is exclusive, so exactly fullFileMaxSignatures still fits.
-	if !wholeFileForm(t, unsignedReport(reportCfg(), atCap, carol, fixedNow).comment) {
-		t.Fatal("want the whole-file form at exactly the cap")
-	}
-}
-
-// Two placeholders in one pasted file is a trap: whoever pastes it fills in their
-// own name, and the other fails validate on the next run before any report runs.
-func TestMultipleSignersFallBackToTheEntryForm(t *testing.T) {
+// A co-author is named but handed no entry: appendOnly would reject one added
+// here, so printing it would be advice that fails on the next run.
+func TestACoauthorIsNamedButGetsNoEntry(t *testing.T) {
 	r := unsignedReport(reportCfg(), file(), []Principal{
 		{ID: 42, Login: "carol", Type: "User"},
 		{ID: 7, Login: "dave", Type: "User"},
-	}, fixedNow)
+	}, nil, fixedNow)
 
-	if wholeFileForm(t, r.comment) {
-		t.Fatalf("want the entry form for two signers, got %q", r.comment)
+	for _, part := range []string{r.text, r.comment, r.markdown} {
+		if !strings.Contains(part, "dave") {
+			t.Errorf("the co-author must be named, got %q", part)
+		}
+		if strings.Contains(part, `"id":    7`) || strings.Contains(part, `"id": 7`) {
+			t.Errorf("the co-author must not be handed an entry to paste, got %q", part)
+		}
+		if !strings.Contains(part, "opened themselves") {
+			t.Errorf("want the way out named, got %q", part)
+		}
 	}
-	if !strings.Contains(r.comment, "replacing each") {
-		t.Fatalf("want the instruction to name every placeholder, got %q", r.comment)
+}
+
+// The opener may already have signed, leaving only a co-author outstanding. There
+// is then nothing for this pull request to add, and the report must not imply
+// otherwise.
+func TestOnlyACoauthorOutstandingOffersNoEntry(t *testing.T) {
+	r := unsignedReport(reportCfg(), file(), []Principal{{ID: 7, Login: "dave", Type: "User"}}, nil, fixedNow)
+
+	if strings.Contains(r.comment, "```json") {
+		t.Errorf("want no entry offered when the opener has signed, got %q", r.comment)
+	}
+	if !strings.Contains(r.comment, "dave") || !strings.Contains(r.comment, "opened themselves") {
+		t.Errorf("want dave named with the way out, got %q", r.comment)
+	}
+	if strings.Contains(r.comment, "\n\n\n") {
+		t.Errorf("want no doubled blank line, got %q", r.comment)
+	}
+}
+
+// A trailer address is commit-message text the pull request chose. It reaches an
+// annotation, a log line and a comment, and must be inert in all three.
+func TestHostileTrailerAddressIsNeutralised(t *testing.T) {
+	hostile := []string{"a%0A::error::forged@x", "[click](https://evil.example)", "back`tick@x"}
+	r := unsignedReport(reportCfg(), file(), []Principal{{ID: 42, Login: "carol", Type: "User"}}, hostile, fixedNow)
+
+	lines := strings.FieldsFunc(r.text, func(r rune) bool { return r == '\n' || r == '\r' })
+	if !strings.HasPrefix(lines[0], "::error::") {
+		t.Fatalf("want the annotation first, got %q", lines[0])
+	}
+	if strings.Contains(lines[0], "%0A::error::") {
+		t.Errorf("a raw %%0A would decode into a second workflow command: %q", lines[0])
+	}
+	for _, l := range lines[1:] {
+		if strings.HasPrefix(l, "::") {
+			t.Errorf("a log line opening with :: is a workflow command: %q", l)
+		}
+	}
+
+	// Markdown gets it inside a code span, so a link renders as its own text.
+	for _, want := range []string{"`[click](https://evil.example)`", "`backtick@x`"} {
+		if !strings.Contains(r.comment, want) {
+			t.Errorf("want %q in the comment, got %q", want, r.comment)
+		}
+	}
+	if strings.Contains(r.comment, "back`tick") {
+		t.Errorf("a backtick would close the span early, got %q", r.comment)
+	}
+}
+
+// The opener is who the comment notifies. With nothing left for them to sign, a
+// heading demanding a signature reads as a demand they have already met.
+func TestHeadingFollowsWhatIsBlocking(t *testing.T) {
+	carol := Principal{ID: 42, Login: "carol", Type: "User"}
+	dave := Principal{ID: 7, Login: "dave", Type: "User"}
+
+	mine := unsignedReport(reportCfg(), file(), []Principal{carol}, nil, fixedNow).comment
+	if !strings.HasPrefix(mine, commentMarker+"\n## CLA signature required") {
+		t.Errorf("want the signature heading when the opener owes one, got %q", mine)
+	}
+
+	theirs := unsignedReport(reportCfg(), file(), []Principal{dave}, nil, fixedNow).comment
+	if !strings.HasPrefix(theirs, commentMarker+"\n## CLA check blocked") {
+		t.Errorf("want the blocked heading when the opener owes nothing, got %q", theirs)
+	}
+	if strings.Contains(theirs, "signature required") {
+		t.Errorf("a signed opener must not be asked to sign, got %q", theirs)
+	}
+	if !strings.Contains(theirs, "Still outstanding:") {
+		t.Errorf("want the blocks introduced, got %q", theirs)
+	}
+}
+
+// A comma-joined list reads as one subject taking a singular verb, so the count
+// has to reach the verb and the noun as well as the join.
+func TestBlocksAgreeInNumber(t *testing.T) {
+	one := Principal{ID: 7, Login: "dave", Type: "User"}
+	two := Principal{ID: 8, Login: "erin", Type: "User"}
+
+	single := unsignedReport(reportCfg(), file(), []Principal{one}, []string{"a@x"}, fixedNow).comment
+	for _, want := range []string{"dave has work", "A Co-authored-by trailer names"} {
+		if !strings.Contains(single, want) {
+			t.Errorf("want %q, got %q", want, single)
+		}
+	}
+
+	plural := unsignedReport(reportCfg(), file(), []Principal{one, two}, []string{"a@x", "b@y"}, fixedNow).comment
+	for _, want := range []string{"dave and erin have work", "Co-authored-by trailers name", "`a@x` and `b@y`"} {
+		if !strings.Contains(plural, want) {
+			t.Errorf("want %q, got %q", want, plural)
+		}
+	}
+
+	if got := joinNames([]string{"a", "b", "c"}); got != "a, b and c" {
+		t.Errorf("joinNames of three = %q", got)
 	}
 }


### PR DESCRIPTION
A missing file at the merge base no longer reads as empty history, the version in force comes from the base tip rather than the merge base, trailer addresses lose CR, and a rejected edit takes the unsigned label instead of a crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified CLA signing requirements for co-authors, AI-assisted commits, signature ownership, and version enforcement.
  - Documented append-only signature rules and pull request expectations.

- **Bug Fixes**
  - Improved validation of contributor identity and noreply email formats.
  - Unrecognized co-authors are now clearly reported and block approval.
  - Rejected signature-file changes are handled consistently as unsigned submissions.
  - Updated reporting to offer signing entries only to the pull request opener.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->