### PR TITLE
feat(cla): sign the CLA by commenting /sign

### DIFF
--- a/.github/workflows/cla-sign.yaml
+++ b/.github/workflows/cla-sign.yaml
@@ -1,0 +1,75 @@
+name: CLA sign
+
+# Signing by comment. A comment's author is the one identity in this flow GitHub
+# attests: a commit's author, its committer and a Co-authored-by trailer are all
+# self-asserted, which is exactly why the checker takes a signature from none of
+# them. The signature is still written as a commit, authored as the contributor,
+# so the record lives in git history under the identity that agreed to it.
+#
+# The signature lands on the base branch rather than the pull request's head
+# because GITHUB_TOKEN cannot push to a fork — which is the case the CLA exists
+# for. The checker reads the base branch by name for the same reason.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  # write, so the signature can be committed to the base branch.
+  contents: write
+  # write, so the contributor is told what happened in a comment rather than only
+  # in a log they have to go looking for.
+  pull-requests: write
+  # write, so the pull request's own CLA run can be re-run. Only a
+  # pull_request_target run attaches to a pull request's checks, so dispatching a
+  # fresh one would execute happily and change nothing the merge button can see.
+  actions: write
+
+concurrency:
+  group: cla-sign-${{ github.event.issue.number }}
+  # Not cancel-in-progress: a cancelled run could stop between committing the
+  # signature and reporting it, leaving a contributor who signed with no reply.
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  sign:
+    # A prefilter only. Actions expressions cannot trim, so an exact `==` here
+    # would silently ignore "/sign " and "/sign\r\n" — the worst failure shape,
+    # since the contributor gets no job, no reply and no clue why. The
+    # authoritative match is in Go, which exits 0 without commenting on a
+    # near-miss, and the token is untouched until it passes.
+    if: >-
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/sign')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # issue_comment always runs the default branch's copy of this file in the
+      # base repository's context, so this checkout is never the pull request's.
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: tools/cla/gate/go.mod
+          cache: false
+
+      - name: Test the signer
+        working-directory: tools/cla/gate
+        run: go test ./...
+
+      - name: Record the signature
+        working-directory: tools/cla/gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENTER_ID: ${{ github.event.comment.user.id }}
+          COMMENTER_LOGIN: ${{ github.event.comment.user.login }}
+          COMMENTER_TYPE: ${{ github.event.comment.user.type }}
+        run: go run . sign

--- a/CLA.md
+++ b/CLA.md
@@ -187,7 +187,13 @@ maximum extent possible under law.
 
 ## How to sign
 
-Signing is a commit. Add yourself to
+The simplest way is to comment `/sign` on a pull request you have work in. That
+records the entry below for you, on the base branch, as a commit authored under
+your own identity — you need not edit any file. GitHub attests the author of a
+comment, which is what lets a comment execute this Agreement where a commit's own
+author field, which the commit merely asserts, cannot.
+
+You can also sign by hand. Add yourself to
 [`tools/cla/signatures.json`](tools/cla/signatures.json) as part of your pull request:
 
 ```json
@@ -197,9 +203,9 @@ Signing is a commit. Add yourself to
   "cla":   "v1" }
 ```
 
-Committing that entry under your own identity is how You execute this Agreement —
-it is the electronic submission the preamble refers to, and it records the version
-of the Agreement you signed in the repository's history. You do it once per
+Either way, recording that entry under your own identity is how You execute this
+Agreement — it is the electronic submission the preamble refers to, and it records
+the version of the Agreement you signed in the repository's history. You do it once per
 version of this Agreement; it covers every Contribution you make afterwards,
 including any you have already Submitted.
 
@@ -217,13 +223,15 @@ check can resolve to an account.
 The file is append-only: the check rejects a pull request that edits or removes an
 existing signature.
 
-You sign for yourself, and only in a pull request you opened — the check accepts no
-other entry. A commit author, a committer and a `Co-authored-by:` trailer are all
+You sign for yourself. A signature added by hand is accepted only in a pull request
+you opened — a commit author, a committer and a `Co-authored-by:` trailer are all
 things the commit itself asserts, so a pull request that could sign for any of them
-could sign for anyone it chose to name. If you co-wrote a contribution with someone
-who has not signed, they sign in a pull request of their own. A trailer naming an
-AI assistant is ignored: an assistant holds no copyright, so there is nothing for
-it to license or to sign.
+could sign for anyone it chose to name. A `/sign` comment is not open to that,
+since GitHub attests who wrote it, so it is accepted from anyone with work in the
+pull request: if you co-wrote a contribution with someone who has not signed, they
+comment `/sign` on it rather than opening a pull request of their own. A trailer
+naming an AI assistant is ignored either way: an assistant holds no copyright, so
+there is nothing for it to license or to sign.
 
 If this Agreement is amended, the new text is published under a new version number
 and contributors are asked to sign again; a signature records the version it was

--- a/tools/cla/gate/check.go
+++ b/tools/cla/gate/check.go
@@ -97,8 +97,15 @@ func (f *SignatureFile) validate() error {
 // superseded version reads as unsigned, so a version bump hands the contributor
 // the ordinary sign-me report instead of failing the file as a whole.
 func (f *SignatureFile) signed(id int64) bool {
+	return f.signedAt(id, f.CLAVersion)
+}
+
+// signedAt is signed() against a version the caller chooses, so the base branch's
+// file can be searched for the version the pull request's head declares rather
+// than its own.
+func (f *SignatureFile) signedAt(id int64, version string) bool {
 	return slices.ContainsFunc(f.Signatures, func(s Signature) bool {
-		return s.ID == id && s.CLA == f.CLAVersion
+		return s.ID == id && s.CLA == version
 	})
 }
 
@@ -212,7 +219,15 @@ func appendOnly(base, head *SignatureFile, signer Principal, inForce string) err
 // and with bots dropped: a machine-authored commit carries no human authorship to
 // license. Every id here was resolved against the API, so a login cannot be
 // shaped to look like a bot and slip through.
-func unsigned(head *SignatureFile, ps []Principal) (missing, checked []Principal) {
+//
+// A principal counts as signed from either file. head is the pull request's own,
+// where a hand-written signature lands; onBase is the base branch as it stands
+// now, where a /sign comment lands one. A contributor's first pull request
+// predates their own signature, so head alone would read them as unsigned however
+// many times they signed. Searching onBase at head's version is safe because
+// appendOnly has already rejected a mismatch between the two files by the time
+// this runs (main.go: appendOnly before unsigned, and it returns on a mismatch).
+func unsigned(head, onBase *SignatureFile, ps []Principal) (missing, checked []Principal) {
 	seen := make(map[int64]bool, len(ps))
 	for _, p := range ps {
 		if p.isBot() || p.ID == 0 || seen[p.ID] {
@@ -220,7 +235,7 @@ func unsigned(head *SignatureFile, ps []Principal) (missing, checked []Principal
 		}
 		seen[p.ID] = true
 		checked = append(checked, p)
-		if !head.signed(p.ID) {
+		if !head.signed(p.ID) && !onBase.signedAt(p.ID, head.CLAVersion) {
 			missing = append(missing, p)
 		}
 	}

--- a/tools/cla/gate/check_test.go
+++ b/tools/cla/gate/check_test.go
@@ -93,11 +93,11 @@ func TestUnsignedIdentifiesPrincipalsByID(t *testing.T) {
 	head := file(sig("alice", 1))
 	// A rename does not lose the signature, and re-registering the freed login
 	// does not inherit it: identity is the id.
-	missing, checked := unsigned(head, []Principal{{ID: 1, Login: "alice-renamed", Type: "User"}})
+	missing, checked := unsigned(head, &SignatureFile{}, []Principal{{ID: 1, Login: "alice-renamed", Type: "User"}})
 	if len(missing) != 0 || len(checked) != 1 {
 		t.Fatalf("renamed signer should pass: missing=%v checked=%v", missing, checked)
 	}
-	missing, _ = unsigned(head, []Principal{{ID: 99, Login: "alice", Type: "User"}})
+	missing, _ = unsigned(head, &SignatureFile{}, []Principal{{ID: 99, Login: "alice", Type: "User"}})
 	if len(missing) != 1 {
 		t.Fatalf("someone re-registering the login must not inherit the signature: %v", missing)
 	}
@@ -108,12 +108,12 @@ func TestUnsignedIdentifiesPrincipalsByID(t *testing.T) {
 // one by adding a file named after it.
 func TestOnlyRealBotsAreExempt(t *testing.T) {
 	head := file()
-	missing, _ := unsigned(head, []Principal{{ID: 1, Login: "dependabot[bot]", Type: "Bot"}})
+	missing, _ := unsigned(head, &SignatureFile{}, []Principal{{ID: 1, Login: "dependabot[bot]", Type: "Bot"}})
 	if len(missing) != 0 {
 		t.Fatalf("a real bot needs no signature, got %v", missing)
 	}
 	for _, login := range []string{"dependabott", "renovateb", "github-actionso", "dependabot[bot]"} {
-		missing, _ := unsigned(head, []Principal{{ID: 5, Login: login, Type: "User"}})
+		missing, _ := unsigned(head, &SignatureFile{}, []Principal{{ID: 5, Login: login, Type: "User"}})
 		if len(missing) != 1 {
 			t.Fatalf("%q is a user account and must sign, got %v", login, missing)
 		}
@@ -128,7 +128,7 @@ func TestUnsignedDeduplicatesAndSkipsUnknownIDs(t *testing.T) {
 		{ID: 2, Login: "bob", Type: "User"},
 		{ID: 0, Login: "", Type: "User"},
 	}
-	missing, checked := unsigned(head, people)
+	missing, checked := unsigned(head, &SignatureFile{}, people)
 	if len(checked) != 2 {
 		t.Fatalf("want 2 distinct principals, got %v", checked)
 	}
@@ -145,7 +145,7 @@ func TestCommitterIsCheckedNotJustAuthor(t *testing.T) {
 	if len(unlinked) != 0 {
 		t.Fatalf("nothing should be unlinked: %v", unlinked)
 	}
-	missing, _ := unsigned(file(sig("alice", 1)), people)
+	missing, _ := unsigned(file(sig("alice", 1)), &SignatureFile{}, people)
 	if len(missing) != 1 || missing[0].Login != "mallory" {
 		t.Fatalf("want the committer flagged, got %v", missing)
 	}
@@ -156,13 +156,13 @@ func TestCommitterIsCheckedNotJustAuthor(t *testing.T) {
 func TestWebFlowCommitterIsIgnored(t *testing.T) {
 	commits := []Commit{commit("a1", user("alice", 1), user("web-flow", webFlowID), "x")}
 	people, _ := principals(commits, Principal{ID: 1, Login: "alice", Type: "User"})
-	missing, _ := unsigned(file(sig("alice", 1)), people)
+	missing, _ := unsigned(file(sig("alice", 1)), &SignatureFile{}, people)
 	if len(missing) != 0 {
 		t.Fatalf("GitHub's web-flow committer is not a copyright holder: %v", missing)
 	}
 	impostor := []Commit{commit("a1", user("alice", 1), user("web-flow", 5), "x")}
 	people, _ = principals(impostor, Principal{ID: 1, Login: "alice", Type: "User"})
-	if missing, _ := unsigned(file(sig("alice", 1)), people); len(missing) != 1 {
+	if missing, _ := unsigned(file(sig("alice", 1)), &SignatureFile{}, people); len(missing) != 1 {
 		t.Fatalf("only the real web-flow id is exempt, got %v", missing)
 	}
 }
@@ -349,5 +349,52 @@ func TestABranchBehindAVersionBumpCannotSignTheRetiredOne(t *testing.T) {
 	err := appendOnly(mergeBase, head, bob, "v2")
 	if err == nil || !strings.Contains(err.Error(), "merge the base branch") {
 		t.Fatalf("want the stale version rejected with the way out, got %v", err)
+	}
+}
+
+// A /sign comment records the signature on the base branch, so a contributor's
+// first pull request predates their own signature. head alone would read them as
+// unsigned however many times they signed.
+func TestUnsignedAcceptsASignatureOnTheBaseBranch(t *testing.T) {
+	head := &SignatureFile{CLAVersion: "v1"}
+	onBase := &SignatureFile{CLAVersion: "v1", Signatures: []Signature{
+		{Login: "nullorm", ID: 78271873, Date: "2026-09-01", CLA: "v1"},
+	}}
+	people := []Principal{{ID: 78271873, Login: "nullorm", Type: "User"}}
+
+	missing, checked := unsigned(head, onBase, people)
+	if len(missing) != 0 {
+		t.Errorf("missing = %v, want none: the signature is on the base branch", missing)
+	}
+	if len(checked) != 1 {
+		t.Errorf("checked = %d, want 1", len(checked))
+	}
+}
+
+// The base branch is searched at the version head declares, so a retired
+// signature does not carry into a bumped version.
+func TestUnsignedIgnoresABaseSignatureAtAnotherVersion(t *testing.T) {
+	head := &SignatureFile{CLAVersion: "v2"}
+	onBase := &SignatureFile{CLAVersion: "v2", Signatures: []Signature{
+		{Login: "nullorm", ID: 78271873, Date: "2026-09-01", CLA: "v1"},
+	}}
+	people := []Principal{{ID: 78271873, Login: "nullorm", Type: "User"}}
+
+	missing, _ := unsigned(head, onBase, people)
+	if len(missing) != 1 {
+		t.Errorf("missing = %v, want nullorm: v1 does not carry over to v2", missing)
+	}
+}
+
+// The pull request's own file still counts, which is the hand-edited path.
+func TestUnsignedStillAcceptsASignatureInHead(t *testing.T) {
+	head := &SignatureFile{CLAVersion: "v1", Signatures: []Signature{
+		{Login: "nullorm", ID: 78271873, Date: "2026-09-01", CLA: "v1"},
+	}}
+	onBase := &SignatureFile{CLAVersion: "v1"}
+	people := []Principal{{ID: 78271873, Login: "nullorm", Type: "User"}}
+
+	if missing, _ := unsigned(head, onBase, people); len(missing) != 0 {
+		t.Errorf("missing = %v, want none: the signature is in head", missing)
 	}
 }

--- a/tools/cla/gate/github.go
+++ b/tools/cla/gate/github.go
@@ -17,6 +17,12 @@ import (
 
 var errNotFound = errors.New("not found")
 
+// errConflict is the contents API refusing a write whose blob sha is stale, which
+// means a signature landed between our read and our write rather than that
+// anything failed. The caller re-reads and retries; every other non-2xx is
+// terminal.
+var errConflict = errors.New("conflict")
+
 const defaultBaseURL = "https://api.github.com"
 
 type client struct {
@@ -206,6 +212,10 @@ func (c *client) send(ctx context.Context, method, endpoint string, payload any)
 	if err != nil {
 		slog.ErrorContext(ctx, "reading the github response failed", slog.String("endpoint", endpoint), errAttr(err))
 		return err
+	}
+	if resp.StatusCode == http.StatusConflict {
+		slog.DebugContext(ctx, "github reported a conflict", slog.String("endpoint", endpoint))
+		return errConflict
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		err := fmt.Errorf("%s %s: %s: %s", method, endpoint, resp.Status, strings.TrimSpace(string(res)))

--- a/tools/cla/gate/github.go
+++ b/tools/cla/gate/github.go
@@ -142,6 +142,42 @@ func (c *client) signatureFileMeta(ctx context.Context, ref string) (*SignatureF
 	return &f, meta.SHA, nil
 }
 
+// noreplyEmail is the address GitHub itself writes for a commit made through the
+// web UI, and the only address form the gate's own trailer resolution accepts.
+func noreplyEmail(p Principal) string {
+	return fmt.Sprintf("%d+%s@users.noreply.github.com", p.ID, p.Login)
+}
+
+// marshalSignatureFile reproduces the file's on-disk shape — two-space indent,
+// trailing newline — so a signature recorded by /sign leaves no reformatting diff
+// against one added by hand, and the next hand-edit does not rewrite the file.
+func marshalSignatureFile(f *SignatureFile) ([]byte, error) {
+	b, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}
+
+// putSignatureFile commits the file to branch. The contributor is the commit
+// author and the workflow's token is the committer, so the record lives in git
+// history under the identity that agreed to it rather than the bot's. sha makes
+// the write conditional; a stale one comes back as errConflict.
+func (c *client) putSignatureFile(ctx context.Context, branch string, f *SignatureFile, sha, message string, author Principal) error {
+	content, err := marshalSignatureFile(f)
+	if err != nil {
+		return err
+	}
+	endpoint := fmt.Sprintf("%s/repos/%s/contents/%s", c.baseURL, c.repo, signaturesPath)
+	return c.send(ctx, http.MethodPut, endpoint, map[string]any{
+		"message": message,
+		"content": base64.StdEncoding.EncodeToString(content),
+		"sha":     sha,
+		"branch":  branch,
+		"author":  map[string]string{"name": author.Login, "email": noreplyEmail(author)},
+	})
+}
+
 var nextPageRe = regexp.MustCompile(`<([^>]+)>;\s*rel="next"`)
 
 // pullCommits walks every page. GitHub caps this endpoint at 250 commits and

--- a/tools/cla/gate/github.go
+++ b/tools/cla/gate/github.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -82,11 +83,16 @@ func (c *client) get(ctx context.Context, endpoint, accept string) ([]byte, http
 	return body, resp.Header, nil
 }
 
+// signaturesPath is the one place the file's location is written down. The gate
+// reads it two ways — raw for a decision, with metadata for a write — and a
+// disagreement between them would read one file and overwrite another.
+const signaturesPath = "tools/cla/signatures.json"
+
 // signatureFile reads tools/cla/signatures.json at a given ref over the API, so the
 // gate never depends on a checkout of the pull request's own tree.
 func (c *client) signatureFile(ctx context.Context, ref string) (*SignatureFile, error) {
-	endpoint := fmt.Sprintf("%s/repos/%s/contents/tools/cla/signatures.json?ref=%s",
-		c.baseURL, c.repo, url.QueryEscape(ref))
+	endpoint := fmt.Sprintf("%s/repos/%s/contents/%s?ref=%s",
+		c.baseURL, c.repo, signaturesPath, url.QueryEscape(ref))
 	body, _, err := c.get(ctx, endpoint, "application/vnd.github.raw")
 	if err != nil {
 		return nil, err
@@ -97,6 +103,43 @@ func (c *client) signatureFile(ctx context.Context, ref string) (*SignatureFile,
 		return nil, fmt.Errorf("tools/cla/signatures.json is not valid JSON: %w", err)
 	}
 	return &f, nil
+}
+
+// signatureFileMeta reads the same file as JSON rather than raw, for the blob sha.
+// That sha is what makes the signer's write conditional: without it a signature
+// landing between the read and the write is silently overwritten instead of
+// rejected, and the loser never learns their signature is gone.
+func (c *client) signatureFileMeta(ctx context.Context, ref string) (*SignatureFile, string, error) {
+	endpoint := fmt.Sprintf("%s/repos/%s/contents/%s?ref=%s",
+		c.baseURL, c.repo, signaturesPath, url.QueryEscape(ref))
+	body, _, err := c.get(ctx, endpoint, "application/vnd.github+json")
+	if err != nil {
+		return nil, "", err
+	}
+	var meta struct {
+		SHA      string `json:"sha"`
+		Content  string `json:"content"`
+		Encoding string `json:"encoding"`
+	}
+	if err := json.Unmarshal(body, &meta); err != nil {
+		slog.ErrorContext(ctx, "the contents response did not decode", slog.String("ref", ref), errAttr(err))
+		return nil, "", fmt.Errorf("the contents response for %s did not decode: %w", signaturesPath, err)
+	}
+	if meta.Encoding != "base64" {
+		return nil, "", fmt.Errorf("the contents response for %s is %q-encoded, not base64", signaturesPath, meta.Encoding)
+	}
+	// GitHub wraps the encoding at 60 characters, and the decoder rejects newlines.
+	raw, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(meta.Content, "\n", ""))
+	if err != nil {
+		slog.ErrorContext(ctx, "the contents response did not decode from base64", slog.String("ref", ref), errAttr(err))
+		return nil, "", fmt.Errorf("the contents response for %s did not decode from base64: %w", signaturesPath, err)
+	}
+	var f SignatureFile
+	if err := json.Unmarshal(raw, &f); err != nil {
+		slog.ErrorContext(ctx, "tools/cla/signatures.json did not decode", slog.String("ref", ref), errAttr(err))
+		return nil, "", fmt.Errorf("%s is not valid JSON: %w", signaturesPath, err)
+	}
+	return &f, meta.SHA, nil
 }
 
 var nextPageRe = regexp.MustCompile(`<([^>]+)>;\s*rel="next"`)

--- a/tools/cla/gate/github.go
+++ b/tools/cla/gate/github.go
@@ -178,6 +178,73 @@ func (c *client) putSignatureFile(ctx context.Context, branch string, f *Signatu
 	})
 }
 
+// PullRequest is the part of the pull request the signer needs and the
+// issue_comment payload does not carry: where to commit, and how many commits to
+// expect so a list truncated at GitHub's 250 cap is caught rather than silently
+// under-reporting who has work here.
+type PullRequest struct {
+	Number  int       `json:"number"`
+	State   string    `json:"state"`
+	Commits int       `json:"commits"`
+	User    Principal `json:"user"`
+	Head    struct {
+		SHA string `json:"sha"`
+	} `json:"head"`
+	Base struct {
+		Ref string `json:"ref"`
+	} `json:"base"`
+}
+
+func (c *client) pullRequest(ctx context.Context, pr int) (PullRequest, error) {
+	endpoint := fmt.Sprintf("%s/repos/%s/pulls/%d", c.baseURL, c.repo, pr)
+	body, _, err := c.get(ctx, endpoint, "application/vnd.github+json")
+	if err != nil {
+		return PullRequest{}, err
+	}
+	var out PullRequest
+	if err := json.Unmarshal(body, &out); err != nil {
+		slog.ErrorContext(ctx, "the pull request response did not decode", slog.Int("pr", pr), errAttr(err))
+		return PullRequest{}, fmt.Errorf("the pull request response did not decode: %w", err)
+	}
+	return out, nil
+}
+
+// WorkflowRun is one run of the checker's workflow. The signer re-runs an existing
+// run rather than dispatching a fresh one: only pull_request_target runs attach to
+// a pull request's checks, so a workflow_dispatch would execute happily and change
+// nothing the merge button can see.
+type WorkflowRun struct {
+	ID     int64  `json:"id"`
+	Status string `json:"status"`
+}
+
+func (c *client) latestWorkflowRun(ctx context.Context, workflowFile, headSHA string) (WorkflowRun, error) {
+	endpoint := fmt.Sprintf("%s/repos/%s/actions/workflows/%s/runs?head_sha=%s&per_page=1",
+		c.baseURL, c.repo, url.PathEscape(workflowFile), url.QueryEscape(headSHA))
+	body, _, err := c.get(ctx, endpoint, "application/vnd.github+json")
+	if err != nil {
+		return WorkflowRun{}, err
+	}
+	var page struct {
+		Runs []WorkflowRun `json:"workflow_runs"`
+	}
+	if err := json.Unmarshal(body, &page); err != nil {
+		slog.ErrorContext(ctx, "the workflow runs response did not decode", errAttr(err))
+		return WorkflowRun{}, fmt.Errorf("the workflow runs response did not decode: %w", err)
+	}
+	// A contributor can comment /sign before the checker has ever run, which is
+	// not a failure — errNotFound lets the caller say so rather than raise.
+	if len(page.Runs) == 0 {
+		return WorkflowRun{}, errNotFound
+	}
+	return page.Runs[0], nil
+}
+
+func (c *client) rerunWorkflow(ctx context.Context, runID int64) error {
+	endpoint := fmt.Sprintf("%s/repos/%s/actions/runs/%d/rerun", c.baseURL, c.repo, runID)
+	return c.send(ctx, http.MethodPost, endpoint, nil)
+}
+
 var nextPageRe = regexp.MustCompile(`<([^>]+)>;\s*rel="next"`)
 
 // pullCommits walks every page. GitHub caps this endpoint at 250 commits and

--- a/tools/cla/gate/github_test.go
+++ b/tools/cla/gate/github_test.go
@@ -238,3 +238,27 @@ func TestLabelWritesUseTheIssueEndpoints(t *testing.T) {
 		t.Fatalf("a delete must not carry a body, got %q", body)
 	}
 }
+
+// A stale blob sha is a signature that landed between the read and the write, not
+// a fault, so it has to be distinguishable from every other non-2xx.
+func TestSendReportsConflictAsErrConflict(t *testing.T) {
+	c := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		fmt.Fprint(w, `{"message":"does not match abc123"}`)
+	})
+	err := c.send(t.Context(), http.MethodPut, c.baseURL+"/x", map[string]string{"a": "b"})
+	if !errors.Is(err, errConflict) {
+		t.Fatalf("send on 409 = %v, want errConflict", err)
+	}
+}
+
+func TestSendStillReportsOtherFailures(t *testing.T) {
+	c := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"message":"forbidden"}`)
+	})
+	err := c.send(t.Context(), http.MethodPut, c.baseURL+"/x", nil)
+	if err == nil || errors.Is(err, errConflict) {
+		t.Fatalf("send on 403 = %v, want a plain error", err)
+	}
+}

--- a/tools/cla/gate/github_test.go
+++ b/tools/cla/gate/github_test.go
@@ -262,3 +262,36 @@ func TestSendStillReportsOtherFailures(t *testing.T) {
 		t.Fatalf("send on 403 = %v, want a plain error", err)
 	}
 }
+
+// GitHub wraps base64 content at 60 characters. A decoder that does not strip the
+// newlines fails on every real response, so the fixture carries one.
+func TestSignatureFileMetaDecodesContentAndSHA(t *testing.T) {
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("ref"); got != "main" {
+			t.Errorf("ref = %q, want main", got)
+		}
+		fmt.Fprint(w, `{"sha":"abc123","encoding":"base64","content":"eyJjbGFfdmVyc2lvbiI6InYxIiwic2ln\nbmF0dXJlcyI6W119"}`)
+	})
+	f, sha, err := c.signatureFileMeta(t.Context(), "main")
+	if err != nil {
+		t.Fatalf("signatureFileMeta: %v", err)
+	}
+	if sha != "abc123" {
+		t.Errorf("sha = %q, want abc123", sha)
+	}
+	if f.CLAVersion != "v1" {
+		t.Errorf("cla_version = %q, want v1", f.CLAVersion)
+	}
+	if f.Signatures == nil {
+		t.Error("signatures decoded as nil, want an empty slice")
+	}
+}
+
+func TestSignatureFileMetaRejectsAnUnexpectedEncoding(t *testing.T) {
+	c := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"sha":"abc123","encoding":"none","content":""}`)
+	})
+	if _, _, err := c.signatureFileMeta(t.Context(), "main"); err == nil {
+		t.Fatal("signatureFileMeta accepted a non-base64 encoding")
+	}
+}

--- a/tools/cla/gate/github_test.go
+++ b/tools/cla/gate/github_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -293,5 +295,67 @@ func TestSignatureFileMetaRejectsAnUnexpectedEncoding(t *testing.T) {
 	})
 	if _, _, err := c.signatureFileMeta(t.Context(), "main"); err == nil {
 		t.Fatal("signatureFileMeta accepted a non-base64 encoding")
+	}
+}
+
+func TestPutSignatureFileSendsAuthorAndSHA(t *testing.T) {
+	var got map[string]any
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decoding the request: %v", err)
+		}
+		fmt.Fprint(w, `{}`)
+	})
+	f := &SignatureFile{CLAVersion: "v1", Signatures: []Signature{
+		{Login: "nullorm", ID: 78271873, Date: "2026-09-01", CLA: "v1"},
+	}}
+	err := c.putSignatureFile(t.Context(), "main", f, "abc123",
+		"chore(cla): sign v1 for @nullorm", Principal{ID: 78271873, Login: "nullorm"})
+	if err != nil {
+		t.Fatalf("putSignatureFile: %v", err)
+	}
+
+	if got["sha"] != "abc123" {
+		t.Errorf("sha = %v, want abc123", got["sha"])
+	}
+	if got["branch"] != "main" {
+		t.Errorf("branch = %v, want main", got["branch"])
+	}
+	// The author is the contributor, so the record stays in git history under the
+	// identity that agreed to it; the committer is whatever the token is.
+	author, _ := got["author"].(map[string]any)
+	if author["email"] != "78271873+nullorm@users.noreply.github.com" {
+		t.Errorf("author email = %v, want the noreply form", author["email"])
+	}
+	if author["name"] != "nullorm" {
+		t.Errorf("author name = %v, want nullorm", author["name"])
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(got["content"].(string))
+	if err != nil {
+		t.Fatalf("content is not base64: %v", err)
+	}
+	// A signature recorded by /sign must leave no reformatting diff against one
+	// added by hand, or the next hand-edit rewrites the whole file.
+	if !strings.HasSuffix(string(decoded), "}\n") {
+		t.Errorf("content does not end with a newline: %q", string(decoded))
+	}
+	if !strings.Contains(string(decoded), `      "login": "nullorm"`) {
+		t.Errorf("content is not indented like the file on disk:\n%s", decoded)
+	}
+}
+
+func TestPutSignatureFilePropagatesAConflict(t *testing.T) {
+	c := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		fmt.Fprint(w, `{"message":"sha does not match"}`)
+	})
+	f := &SignatureFile{CLAVersion: "v1"}
+	err := c.putSignatureFile(t.Context(), "main", f, "stale", "m", Principal{ID: 1, Login: "a"})
+	if !errors.Is(err, errConflict) {
+		t.Fatalf("putSignatureFile on 409 = %v, want errConflict", err)
 	}
 }

--- a/tools/cla/gate/github_test.go
+++ b/tools/cla/gate/github_test.go
@@ -359,3 +359,74 @@ func TestPutSignatureFilePropagatesAConflict(t *testing.T) {
 		t.Fatalf("putSignatureFile on 409 = %v, want errConflict", err)
 	}
 }
+
+// issue_comment carries the issue, not the pull request, so the signer has
+// neither the base branch nor the commit count and must read both.
+func TestPullRequestDecodesBaseAndCommits(t *testing.T) {
+	c := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"number":107,"state":"open","commits":3,
+			"user":{"id":876188,"login":"poluruprvn","type":"User"},
+			"head":{"sha":"deadbeef"},"base":{"ref":"main"}}`)
+	})
+	pr, err := c.pullRequest(t.Context(), 107)
+	if err != nil {
+		t.Fatalf("pullRequest: %v", err)
+	}
+	if pr.Base.Ref != "main" {
+		t.Errorf("base ref = %q, want main", pr.Base.Ref)
+	}
+	if pr.Head.SHA != "deadbeef" {
+		t.Errorf("head sha = %q, want deadbeef", pr.Head.SHA)
+	}
+	if pr.Commits != 3 {
+		t.Errorf("commits = %d, want 3", pr.Commits)
+	}
+	if pr.User.Login != "poluruprvn" || pr.User.ID != 876188 {
+		t.Errorf("opener = %+v, want poluruprvn/876188", pr.User)
+	}
+	if pr.State != "open" {
+		t.Errorf("state = %q, want open", pr.State)
+	}
+}
+
+func TestLatestWorkflowRunAndRerun(t *testing.T) {
+	var rerun int64
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/rerun"):
+			rerun = 991
+			w.WriteHeader(http.StatusCreated)
+		case strings.Contains(r.URL.Path, "/runs"):
+			if got := r.URL.Query().Get("head_sha"); got != "deadbeef" {
+				t.Errorf("head_sha = %q, want deadbeef", got)
+			}
+			fmt.Fprint(w, `{"workflow_runs":[{"id":991,"status":"completed"}]}`)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	})
+	run, err := c.latestWorkflowRun(t.Context(), "cla.yaml", "deadbeef")
+	if err != nil {
+		t.Fatalf("latestWorkflowRun: %v", err)
+	}
+	if run.ID != 991 {
+		t.Fatalf("run id = %d, want 991", run.ID)
+	}
+	if err := c.rerunWorkflow(t.Context(), run.ID); err != nil {
+		t.Fatalf("rerunWorkflow: %v", err)
+	}
+	if rerun != 991 {
+		t.Errorf("rerun called for %d, want 991", rerun)
+	}
+}
+
+// No run yet is an ordinary outcome — a contributor can comment /sign before the
+// checker has ever run — so it must not read as an API failure.
+func TestLatestWorkflowRunReportsNoRunAsNotFound(t *testing.T) {
+	c := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"workflow_runs":[]}`)
+	})
+	if _, err := c.latestWorkflowRun(t.Context(), "cla.yaml", "deadbeef"); !errors.Is(err, errNotFound) {
+		t.Fatalf("latestWorkflowRun with no runs = %v, want errNotFound", err)
+	}
+}

--- a/tools/cla/gate/main.go
+++ b/tools/cla/gate/main.go
@@ -126,12 +126,32 @@ type checker struct {
 	now func() time.Time
 }
 
+// subcommand picks what to run. A bare invocation stays the checker, so cla.yaml
+// is untouched by the signer's arrival. Anything else unrecognised is a typo, not
+// a mode: falling through to the checker would report a signature that was never
+// recorded, which is worse than any error.
+func subcommand(args []string) (func(context.Context) error, bool) {
+	if len(args) < 2 {
+		return run, true
+	}
+	if args[1] == "sign" {
+		return runSign, true
+	}
+	return nil, false
+}
+
 func main() {
 	setupLogging()
 
+	do, ok := subcommand(os.Args)
+	if !ok {
+		fmt.Printf("::error::unknown subcommand %q; use `sign` or no argument\n", escapeAnnotation(os.Args[1]))
+		os.Exit(1)
+	}
+
 	// An unsigned CLA has already been reported with its own annotation; anything
 	// else is a checker fault that nothing has annotated yet.
-	switch err := run(context.Background()); {
+	switch err := do(context.Background()); {
 	case errors.Is(err, errUnsigned):
 		os.Exit(1)
 	case err != nil:

--- a/tools/cla/gate/main.go
+++ b/tools/cla/gate/main.go
@@ -208,7 +208,12 @@ func (c *checker) verdict(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	inForce, err := c.gh.signatureFile(ctx, c.cfg.baseSHA)
+	// The base branch as it stands now, not the event's pinned base.sha. A
+	// workflow re-run replays the original payload, so a signature committed by a
+	// /sign comment after the event fired would be invisible on exactly the run
+	// that has to see it. signatureFile passes its ref to ?ref=, which takes a
+	// branch name; baseRef is a base-repo branch and never the pull request's.
+	inForce, err := c.gh.signatureFile(ctx, c.cfg.baseRef)
 	if err != nil {
 		return fmt.Errorf("reading tools/cla/signatures.json on %s: %w", c.cfg.baseRef, err)
 	}
@@ -221,7 +226,7 @@ func (c *checker) verdict(ctx context.Context) error {
 		return errUnsigned
 	}
 
-	missing, checked := unsigned(head, people)
+	missing, checked := unsigned(head, inForce, people)
 	if len(missing) > 0 || len(unknown) > 0 {
 		report := unsignedReport(c.cfg, head, missing, unknown, c.now())
 		fmt.Fprint(c.out, report.text)

--- a/tools/cla/gate/main.go
+++ b/tools/cla/gate/main.go
@@ -104,6 +104,11 @@ type githubAPI interface {
 	pullCommits(ctx context.Context, pr int) ([]Commit, error)
 	mergeBase(ctx context.Context, base, head string) (string, error)
 	userByLogin(ctx context.Context, login string) (Principal, error)
+	signatureFileMeta(ctx context.Context, ref string) (*SignatureFile, string, error)
+	putSignatureFile(ctx context.Context, branch string, f *SignatureFile, sha, message string, author Principal) error
+	pullRequest(ctx context.Context, pr int) (PullRequest, error)
+	latestWorkflowRun(ctx context.Context, workflowFile, headSHA string) (WorkflowRun, error)
+	rerunWorkflow(ctx context.Context, runID int64) error
 	comments(ctx context.Context, pr int) ([]Comment, error)
 	createComment(ctx context.Context, pr int, body string) error
 	updateComment(ctx context.Context, id int64, body string) error
@@ -198,7 +203,7 @@ func (c *checker) verdict(ctx context.Context) error {
 	// An unidentified co-author blocks the gate like an unsigned one — a trailer
 	// names a copyright holder either way — but is reported rather than raised: it
 	// is the contributor's to fix, and a checker error would bury the report.
-	coauthors, unknown, err := c.resolveCoauthors(ctx, commits)
+	coauthors, unknown, err := resolveCoauthors(ctx, c.gh, commits)
 	if err != nil {
 		return err
 	}
@@ -332,7 +337,11 @@ func (c *checker) baseFile(ctx context.Context) (*SignatureFile, error) {
 	return base, nil
 }
 
-// resolveCoauthors turns Co-authored-by trailers into principals. A trailer is
+// resolveCoauthors turns Co-authored-by trailers into principals. It takes the
+// API rather than hanging off the checker: the signer needs exactly this list to
+// decide who may sign, and two implementations of "who is a principal" — one
+// deciding who must sign and one deciding who may — is the single disagreement
+// this system cannot survive. A trailer is
 // commit-message text, so nothing in it is taken on trust — the address only
 // chooses which login is looked up, and the id always comes back from the API.
 //
@@ -346,7 +355,7 @@ func (c *checker) baseFile(ctx context.Context) (*SignatureFile, error) {
 // to answer is an error instead, since "we could not reach GitHub" must not reach
 // the contributor as "your co-author has not signed". A known assistant is
 // neither: it names no copyright holder, so it is skipped rather than reported.
-func (c *checker) resolveCoauthors(ctx context.Context, commits []Commit) (found []Principal, unknown []string, err error) {
+func resolveCoauthors(ctx context.Context, gh githubAPI, commits []Commit) (found []Principal, unknown []string, err error) {
 	for _, email := range coauthorEmails(commits) {
 		if isAssistant(email) {
 			continue
@@ -356,7 +365,7 @@ func (c *checker) resolveCoauthors(ctx context.Context, commits []Commit) (found
 			unknown = append(unknown, email)
 			continue
 		}
-		p, err := c.gh.userByLogin(ctx, login)
+		p, err := gh.userByLogin(ctx, login)
 		if err != nil && !errors.Is(err, errNotFound) {
 			return nil, nil, fmt.Errorf("resolving the co-author %s: %w\nIf GitHub's API was erroring, re-running the job is enough", email, err)
 		}

--- a/tools/cla/gate/main_test.go
+++ b/tools/cla/gate/main_test.go
@@ -29,6 +29,57 @@ type fakeGitHub struct {
 
 	labelled    []string
 	labelWrites int
+
+	// the signer's surface
+	fileSHA      string
+	pr           PullRequest
+	putFile      *SignatureFile
+	putBranch    string
+	putAttempts  int
+	putConflicts int
+	putErr       error
+	runErr       error
+	rerunID      int64
+}
+
+func (f *fakeGitHub) signatureFileMeta(_ context.Context, ref string) (*SignatureFile, string, error) {
+	sf, ok := f.files[ref]
+	if !ok {
+		return nil, "", errNotFound
+	}
+	// A clone, because the signer appends to what it reads and a retry has to see
+	// the file as it stands rather than its own half-finished previous attempt.
+	clone := *sf
+	clone.Signatures = slices.Clone(sf.Signatures)
+	return &clone, f.fileSHA, nil
+}
+
+func (f *fakeGitHub) putSignatureFile(_ context.Context, branch string, sf *SignatureFile, _, _ string, _ Principal) error {
+	f.putAttempts++
+	if f.putConflicts > 0 {
+		f.putConflicts--
+		return errConflict
+	}
+	if f.putErr != nil {
+		return f.putErr
+	}
+	f.putBranch, f.putFile = branch, sf
+	f.files[branch] = sf
+	return nil
+}
+
+func (f *fakeGitHub) pullRequest(context.Context, int) (PullRequest, error) { return f.pr, nil }
+
+func (f *fakeGitHub) latestWorkflowRun(context.Context, string, string) (WorkflowRun, error) {
+	if f.runErr != nil {
+		return WorkflowRun{}, f.runErr
+	}
+	return WorkflowRun{ID: 991, Status: "completed"}, nil
+}
+
+func (f *fakeGitHub) rerunWorkflow(_ context.Context, id int64) error {
+	f.rerunID = id
+	return nil
 }
 
 func (f *fakeGitHub) signatureFile(_ context.Context, ref string) (*SignatureFile, error) {
@@ -223,7 +274,7 @@ func TestResolveCoauthorsRaisesALookupFailure(t *testing.T) {
 		"feat: thing\n\nCo-authored-by: Carol <carol@users.noreply.github.com>\n")}
 
 	c := newChecker(&fakeGitHub{lookupErr: errors.New("403 rate limit exceeded")}, &bytes.Buffer{})
-	_, unknown, err := c.resolveCoauthors(t.Context(), commits)
+	_, unknown, err := resolveCoauthors(t.Context(), c.gh, commits)
 	if err == nil || len(unknown) != 0 {
 		t.Fatalf("want the failure raised, got unknown=%v err=%v", unknown, err)
 	}
@@ -237,7 +288,7 @@ func TestResolveCoauthorsReportsAPlaintextAddress(t *testing.T) {
 		"feat: thing\n\nCo-authored-by: Carol <carol@example.com>\n")}
 
 	c := newChecker(&fakeGitHub{}, &bytes.Buffer{})
-	found, unknown, err := c.resolveCoauthors(t.Context(), commits)
+	found, unknown, err := resolveCoauthors(t.Context(), c.gh, commits)
 	if err != nil || len(found) != 0 || len(unknown) != 1 || unknown[0] != "carol@example.com" {
 		t.Fatalf("want the address reported, got found=%v unknown=%v err=%v", found, unknown, err)
 	}
@@ -250,14 +301,14 @@ func TestResolveCoauthorsReportsAPlaintextAddress(t *testing.T) {
 func TestAnAssistantTrailerIsSkippedButAPersonsIsNot(t *testing.T) {
 	msg := "feat: thing\n\nCo-authored-by: Claude <noreply@anthropic.com>\n"
 	c := newChecker(&fakeGitHub{}, &bytes.Buffer{})
-	found, unknown, err := c.resolveCoauthors(t.Context(),
+	found, unknown, err := resolveCoauthors(t.Context(), c.gh,
 		[]Commit{commit("a1", user("alice", 1), user("alice", 1), msg)})
 	if err != nil || len(found) != 0 || len(unknown) != 0 {
 		t.Fatalf("an assistant licenses nothing and must not block, got found=%v unknown=%v err=%v", found, unknown, err)
 	}
 
 	person := "feat: thing\n\nCo-authored-by: Carol <carol@anthropic.com>\n"
-	_, unknown, err = c.resolveCoauthors(t.Context(),
+	_, unknown, err = resolveCoauthors(t.Context(), c.gh,
 		[]Commit{commit("a1", user("alice", 1), user("alice", 1), person)})
 	if err != nil || len(unknown) != 1 {
 		t.Fatalf("a colleague at the same domain still holds copyright, got unknown=%v err=%v", unknown, err)
@@ -293,7 +344,7 @@ func TestResolveCoauthorsFallsBackToTheAPIForTheIDLessNoreplyForm(t *testing.T) 
 		"feat: thing\n\nCo-authored-by: Bob <bob@users.noreply.github.com>\n")}
 
 	c := newChecker(&fakeGitHub{byLogin: map[string]Principal{"bob": {ID: 99, Login: "bob", Type: "User"}}}, &bytes.Buffer{})
-	found, unknown, err := c.resolveCoauthors(t.Context(), commits)
+	found, unknown, err := resolveCoauthors(t.Context(), c.gh, commits)
 	if err != nil || len(unknown) != 0 || len(found) != 1 || found[0].ID != 99 {
 		t.Fatalf("want bob resolved to id 99, got found=%v unknown=%v err=%v", found, unknown, err)
 	}

--- a/tools/cla/gate/main_test.go
+++ b/tools/cla/gate/main_test.go
@@ -896,3 +896,17 @@ func TestAnAssistantTrailerAloneDoesNotBlockTheGate(t *testing.T) {
 		}
 	}
 }
+
+// A mistyped subcommand must not silently fall through to the checker: reporting
+// a signature that was never recorded is the one outcome worse than an error.
+func TestSubcommandRejectsAnUnknownArgument(t *testing.T) {
+	if _, ok := subcommand([]string{"gate", "sing"}); ok {
+		t.Error(`subcommand accepted "sing"`)
+	}
+	if _, ok := subcommand([]string{"gate"}); !ok {
+		t.Error("subcommand rejected a bare invocation, which is the checker")
+	}
+	if _, ok := subcommand([]string{"gate", "sign"}); !ok {
+		t.Error(`subcommand rejected "sign"`)
+	}
+}

--- a/tools/cla/gate/main_test.go
+++ b/tools/cla/gate/main_test.go
@@ -35,6 +35,15 @@ func (f *fakeGitHub) signatureFile(_ context.Context, ref string) (*SignatureFil
 	if sf, ok := f.files[ref]; ok {
 		return sf, nil
 	}
+	// The checker reads the version in force at the base branch by name. In the
+	// ordinary case that branch and the merge base carry the same file, so "main"
+	// falls back to the merge base's entry; a test that needs them to differ —
+	// which is what a /sign comment produces — seeds "main" explicitly.
+	if ref == "main" {
+		if sf, ok := f.files["base"]; ok {
+			return sf, nil
+		}
+	}
 	return nil, errNotFound
 }
 

--- a/tools/cla/gate/sign.go
+++ b/tools/cla/gate/sign.go
@@ -10,11 +10,14 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"slices"
 	"strconv"
+	"time"
 )
 
 // signWorkflowFile is the checker's workflow, re-run once a signature lands so the
@@ -26,13 +29,15 @@ type signConfig struct {
 	repo      string
 	pr        int
 	commenter Principal
+	serverURL string
 	token     string
 }
 
 func loadSignConfig() (signConfig, error) {
 	c := signConfig{
-		repo:  os.Getenv("GITHUB_REPOSITORY"),
-		token: env("GH_TOKEN", os.Getenv("GITHUB_TOKEN")),
+		repo:      os.Getenv("GITHUB_REPOSITORY"),
+		serverURL: env("GITHUB_SERVER_URL", "https://github.com"),
+		token:     env("GH_TOKEN", os.Getenv("GITHUB_TOKEN")),
 	}
 	var err error
 	if c.pr, err = strconv.Atoi(os.Getenv("PR_NUMBER")); err != nil {
@@ -101,4 +106,150 @@ func maySign(commenter Principal, people []Principal, head, onBase *SignatureFil
 		return errNotAPrincipal
 	}
 	return nil
+}
+
+// putRetries is one retry, not a loop. A conflict means another signature landed;
+// a second one in the time it takes to re-read is not congestion but a bug, and
+// spinning on it would hold the runner while making it worse.
+const putRetries = 1
+
+// rerunFailed is advice, not an apology: the signature is committed either way, so
+// what the contributor needs is the one action that gets their check re-run.
+const rerunFailed = "\n\nThe CLA check could not be re-run automatically — push any commit, or ask a maintainer to re-run it."
+
+type signer struct {
+	cfg signConfig
+	gh  githubAPI
+	now func() time.Time
+}
+
+func (s *signer) sign(ctx context.Context) error {
+	pr, err := s.gh.pullRequest(ctx, s.cfg.pr)
+	if err != nil {
+		return fmt.Errorf("reading pull request %d: %w", s.cfg.pr, err)
+	}
+	slog.InfoContext(ctx, "recording a signature",
+		slog.String("repo", s.cfg.repo), slog.Int("pr", s.cfg.pr),
+		slog.String("commenter", s.cfg.commenter.Login), slog.String("base", pr.Base.Ref))
+
+	commits, err := s.gh.pullCommits(ctx, s.cfg.pr)
+	if err != nil {
+		return fmt.Errorf("listing commits: refusing to sign against an unverified list: %w", err)
+	}
+	// The checker's own 250-cap guard. A truncated list here would drop principals
+	// and refuse a contributor who really is one.
+	if len(commits) != pr.Commits {
+		return fmt.Errorf("listed %d of the pull request's %d commits, so a principal could be missed; GitHub caps that endpoint at 250, so squash or split a pull request that large, otherwise re-run the job",
+			len(commits), pr.Commits)
+	}
+
+	// An unlinked commit email is left to the checker to report: it blocks the
+	// gate there with a fuller explanation, and refusing to sign over it would
+	// only add a second, vaguer message about the same problem.
+	people, _ := principals(commits, pr.User)
+	coauthors, _, err := resolveCoauthors(ctx, s.gh, commits)
+	if err != nil {
+		return err
+	}
+	people = append(people, coauthors...)
+
+	head, err := s.gh.signatureFile(ctx, pr.Head.SHA)
+	if err != nil {
+		return fmt.Errorf("reading %s at the pull request head: %w", signaturesPath, err)
+	}
+
+	for attempt := 0; ; attempt++ {
+		onBase, sha, err := s.gh.signatureFileMeta(ctx, pr.Base.Ref)
+		if err != nil {
+			return fmt.Errorf("reading %s on %s: %w", signaturesPath, pr.Base.Ref, err)
+		}
+		if err := maySign(s.cfg.commenter, people, head, onBase, onBase.CLAVersion); err != nil {
+			return s.decline(ctx, err)
+		}
+
+		onBase.Signatures = append(onBase.Signatures, Signature{
+			Login: s.cfg.commenter.Login,
+			ID:    s.cfg.commenter.ID,
+			Date:  s.now().UTC().Format(time.DateOnly),
+			CLA:   onBase.CLAVersion,
+		})
+		// Validate what is about to be written, not what was read: the signer must
+		// never be the thing that makes the file unparseable for everyone else.
+		if err := onBase.validate(); err != nil {
+			return fmt.Errorf("the signature would make %s invalid: %w", signaturesPath, err)
+		}
+
+		msg := fmt.Sprintf("chore(cla): sign %s for @%s", onBase.CLAVersion, s.cfg.commenter.Login)
+		err = s.gh.putSignatureFile(ctx, pr.Base.Ref, onBase, sha, msg, s.cfg.commenter)
+		switch {
+		case err == nil:
+			return s.confirm(ctx, pr, onBase.CLAVersion)
+		case errors.Is(err, errConflict) && attempt < putRetries:
+			slog.InfoContext(ctx, "another signature landed first; re-reading", slog.Int("attempt", attempt+1))
+		default:
+			return fmt.Errorf("committing the signature to %s: %w", pr.Base.Ref, err)
+		}
+	}
+}
+
+// confirm tells the contributor the signature landed and re-runs the checker, so
+// the pull request's own required check turns green rather than a second one
+// agreeing with it. The re-run is best-effort: the signature is committed either
+// way, and failing here would report a signing that happened as one that did not.
+func (s *signer) confirm(ctx context.Context, pr PullRequest, version string) error {
+	body := fmt.Sprintf("Signed CLA **%s** for @%s — recorded in `%s` on `%s`. Thanks!",
+		version, s.cfg.commenter.Login, signaturesPath, pr.Base.Ref)
+
+	switch run, err := s.gh.latestWorkflowRun(ctx, signWorkflowFile, pr.Head.SHA); {
+	case errors.Is(err, errNotFound):
+		body += "\n\nNo CLA check has run here yet; the first one will pass."
+	case err != nil:
+		slog.ErrorContext(ctx, "could not find the CLA run to re-run", errAttr(err))
+		body += rerunFailed
+	default:
+		if err := s.gh.rerunWorkflow(ctx, run.ID); err != nil {
+			slog.ErrorContext(ctx, "could not re-run the CLA check", errAttr(err))
+			body += rerunFailed
+		}
+	}
+
+	if err := s.gh.createComment(ctx, s.cfg.pr, body); err != nil {
+		slog.ErrorContext(ctx, "could not post the confirmation", errAttr(err))
+	}
+	return nil
+}
+
+// decline reports why no signature was recorded.
+//
+// Already-signed is not a failure: a contributor commenting twice, or one whose
+// first /sign landed before the check re-ran, already has what they came for, and
+// painting the pull request red for it would be a lie about the state of things.
+// It replies and exits green. Every other reason fails the job — a refusal that
+// exited 0 would leave a green tick and no signature.
+func (s *signer) decline(ctx context.Context, reason error) error {
+	body := fmt.Sprintf("@%s — %s.", s.cfg.commenter.Login, reason)
+	settled := errors.Is(reason, errAlreadySigned)
+	if !settled {
+		body += fmt.Sprintf("\n\nSee [CLA.md](%s/%s/blob/HEAD/CLA.md) for how signing works.", s.cfg.serverURL, s.cfg.repo)
+	}
+	if err := s.gh.createComment(ctx, s.cfg.pr, body); err != nil {
+		slog.ErrorContext(ctx, "could not post the reply", errAttr(err))
+	}
+	if settled {
+		slog.InfoContext(ctx, "nothing to record", slog.String("commenter", s.cfg.commenter.Login))
+		return nil
+	}
+	return fmt.Errorf("refused to sign for %s: %w", s.cfg.commenter.Login, reason)
+}
+
+func runSign(ctx context.Context) error {
+	cfg, err := loadSignConfig()
+	if err != nil {
+		return fmt.Errorf("configuration: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(ctx, runTimeout)
+	defer cancel()
+
+	s := &signer{cfg: cfg, gh: newClient(cfg.token, cfg.repo), now: time.Now}
+	return s.sign(ctx)
 }

--- a/tools/cla/gate/sign.go
+++ b/tools/cla/gate/sign.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 )
 
@@ -56,4 +57,48 @@ func loadSignConfig() (signConfig, error) {
 		return c, errors.New("COMMENTER_LOGIN is empty")
 	}
 	return c, nil
+}
+
+// Refusals a contributor can meet. Each is reported verbatim in the reply, so
+// whichever one fires is the whole of what they are told.
+var (
+	errNotAPrincipal = errors.New("you have no commits, and no co-author trailer, in this pull request")
+	errAlreadySigned = errors.New("you have already signed the version in force")
+	errBotCommenter  = errors.New("a bot holds no copyright, so it has nothing to license")
+)
+
+// maySign decides whether this comment records a signature, and when it does not,
+// which reason the contributor is told.
+//
+// commenter is GitHub-attested, so its identity is not in question. people is
+// every principal on the pull request: the opener, every commit author and
+// committer, and every resolved Co-authored-by trailer. head is the pull
+// request's own signature file and onBase the base branch's; a signature in
+// either one already covers this version. version is the one in force.
+//
+// More than one reason can be true at once — a bot that is not a principal and
+// has somehow signed hits three — so the order of the checks is the order of the
+// contributor's experience: whichever fires first is the only message they read.
+//
+// Returns nil to accept.
+func maySign(commenter Principal, people []Principal, head, onBase *SignatureFile, version string) error {
+	// A bot first. It is the one refusal that holds whatever the pull request
+	// says, and telling a machine which humans have signed is noise nobody reads.
+	if commenter.isBot() {
+		return errBotCommenter
+	}
+	// Before principal-hood, deliberately. Someone who signed on an earlier pull
+	// request and comments /sign on a colleague's would otherwise be told they
+	// have no work here — true, and it sends them hunting for a problem they do
+	// not have. Both files are searched at the version in force, never at their
+	// own: onBase can declare a different one mid-bump.
+	if head.signedAt(commenter.ID, version) || onBase.signedAt(commenter.ID, version) {
+		return errAlreadySigned
+	}
+	// The only security-relevant check, and the one never to soften: without it
+	// the file fills with entries from people who have never contributed.
+	if !slices.ContainsFunc(people, func(p Principal) bool { return p.ID == commenter.ID }) {
+		return errNotAPrincipal
+	}
+	return nil
 }

--- a/tools/cla/gate/sign.go
+++ b/tools/cla/gate/sign.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -24,6 +25,11 @@ import (
 // pull request's own required check turns green rather than a second check
 // merely agreeing with it.
 const signWorkflowFile = "cla.yaml"
+
+// signCommand is the whole comment, not a prefix of it. The workflow gates on a
+// prefix because Actions expressions cannot trim, so this is the authoritative
+// match.
+const signCommand = "/sign"
 
 type signConfig struct {
 	repo      string
@@ -243,6 +249,14 @@ func (s *signer) decline(ctx context.Context, reason error) error {
 }
 
 func runSign(ctx context.Context) error {
+	// A near-miss exits quietly rather than replying: the contributor meant
+	// something else, and a refusal posted under every "I'll /sign later" would be
+	// worse than saying nothing.
+	if body := strings.TrimSpace(os.Getenv("COMMENT_BODY")); body != signCommand {
+		slog.InfoContext(ctx, "comment is not the sign command; nothing to do")
+		return nil
+	}
+
 	cfg, err := loadSignConfig()
 	if err != nil {
 		return fmt.Errorf("configuration: %w", err)

--- a/tools/cla/gate/sign.go
+++ b/tools/cla/gate/sign.go
@@ -1,0 +1,59 @@
+// The signer records a signature on behalf of someone who asked for it in a pull
+// request comment.
+//
+// A comment's author is the one identity in this flow GitHub attests. A commit's
+// author, its committer and a Co-authored-by trailer are all self-asserted, which
+// is exactly why the checker refuses to take a signature from any of them; a
+// comment carries no such doubt, so it can execute the agreement where those
+// cannot. The signature is still written as a commit, authored as the
+// contributor, so the record lives in git history under the identity that agreed.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// signWorkflowFile is the checker's workflow, re-run once a signature lands so the
+// pull request's own required check turns green rather than a second check
+// merely agreeing with it.
+const signWorkflowFile = "cla.yaml"
+
+type signConfig struct {
+	repo      string
+	pr        int
+	commenter Principal
+	token     string
+}
+
+func loadSignConfig() (signConfig, error) {
+	c := signConfig{
+		repo:  os.Getenv("GITHUB_REPOSITORY"),
+		token: env("GH_TOKEN", os.Getenv("GITHUB_TOKEN")),
+	}
+	var err error
+	if c.pr, err = strconv.Atoi(os.Getenv("PR_NUMBER")); err != nil {
+		return c, fmt.Errorf("PR_NUMBER: %w", err)
+	}
+	id, err := strconv.ParseInt(os.Getenv("COMMENTER_ID"), 10, 64)
+	if err != nil {
+		return c, fmt.Errorf("COMMENTER_ID: %w", err)
+	}
+	c.commenter = Principal{ID: id, Login: os.Getenv("COMMENTER_LOGIN"), Type: env("COMMENTER_TYPE", "User")}
+	// Each of these weakens the signer if it is missing rather than wrong: a zero
+	// id names nobody to sign for, and an absent token downgrades the run to the
+	// unauthenticated rate limit before failing the write outright.
+	switch {
+	case c.repo == "":
+		return c, errors.New("GITHUB_REPOSITORY is empty")
+	case c.token == "":
+		return c, errors.New("GH_TOKEN is empty")
+	case c.commenter.ID == 0:
+		return c, errors.New("COMMENTER_ID is zero")
+	case c.commenter.Login == "":
+		return c, errors.New("COMMENTER_LOGIN is empty")
+	}
+	return c, nil
+}

--- a/tools/cla/gate/sign_test.go
+++ b/tools/cla/gate/sign_test.go
@@ -273,9 +273,28 @@ func TestSignRefusesToActOnATruncatedCommitList(t *testing.T) {
 }
 
 func TestRunSignRefusesAnEmptyConfiguration(t *testing.T) {
+	t.Setenv("COMMENT_BODY", signCommand)
 	t.Setenv("GITHUB_REPOSITORY", "")
 	t.Setenv("PR_NUMBER", "")
 	if err := runSign(t.Context()); err == nil {
 		t.Fatal("runSign accepted an empty configuration")
+	}
+}
+
+// Actions expressions cannot trim, so the workflow's `if:` is only a prefilter and
+// the exact match happens here.
+func TestRunSignIgnoresACommentThatMerelyMentionsTheCommand(t *testing.T) {
+	t.Setenv("COMMENT_BODY", "I'll /sign this later, promise")
+	if err := runSign(t.Context()); err != nil {
+		t.Fatalf("runSign on an unrelated comment = %v, want a quiet nil", err)
+	}
+}
+
+func TestRunSignToleratesSurroundingWhitespace(t *testing.T) {
+	t.Setenv("COMMENT_BODY", "  /sign\r\n")
+	t.Setenv("GITHUB_REPOSITORY", "")
+	// Reaching the configuration error proves the body was accepted as the command.
+	if err := runSign(t.Context()); err == nil {
+		t.Fatal("runSign treated a padded /sign as a non-command")
 	}
 }

--- a/tools/cla/gate/sign_test.go
+++ b/tools/cla/gate/sign_test.go
@@ -271,3 +271,11 @@ func TestSignRefusesToActOnATruncatedCommitList(t *testing.T) {
 		t.Errorf("wrote on an untrusted principal list: %d attempts", gh.putAttempts)
 	}
 }
+
+func TestRunSignRefusesAnEmptyConfiguration(t *testing.T) {
+	t.Setenv("GITHUB_REPOSITORY", "")
+	t.Setenv("PR_NUMBER", "")
+	if err := runSign(t.Context()); err == nil {
+		t.Fatal("runSign accepted an empty configuration")
+	}
+}

--- a/tools/cla/gate/sign_test.go
+++ b/tools/cla/gate/sign_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"errors"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestLoadSignConfigReadsTheCommenter(t *testing.T) {
@@ -141,5 +143,131 @@ func TestMaySignRefusesABot(t *testing.T) {
 	err := maySign(Principal{ID: 49699333, Login: "dependabot[bot]", Type: "Bot"}, people, head, onBase, "v1")
 	if !errors.Is(err, errBotCommenter) {
 		t.Fatalf("maySign for a bot = %v, want errBotCommenter", err)
+	}
+}
+
+// signable builds a pull request opened by nullorm with one commit of their own,
+// nothing signed anywhere. The base branch and the head agree, which is the state
+// a first-time contributor's pull request is actually in.
+func signable() *fakeGitHub {
+	gh := &fakeGitHub{
+		files: map[string]*SignatureFile{
+			"main":     {CLAVersion: "v1", Signatures: []Signature{}},
+			"deadbeef": {CLAVersion: "v1", Signatures: []Signature{}},
+		},
+		fileSHA: "abc123",
+		pr:      PullRequest{Number: 107, State: "open", Commits: 1, User: Principal{ID: 78271873, Login: "nullorm", Type: "User"}},
+		commits: []Commit{{SHA: "c1", Author: &Principal{ID: 78271873, Login: "nullorm", Type: "User"}}},
+	}
+	gh.pr.Head.SHA = "deadbeef"
+	gh.pr.Base.Ref = "main"
+	return gh
+}
+
+func newSigner(gh githubAPI, commenter Principal) *signer {
+	return &signer{
+		cfg: signConfig{repo: "pug-sh/pug", pr: 107, token: "t", commenter: commenter},
+		gh:  gh,
+		now: func() time.Time { return fixedNow },
+	}
+}
+
+var nullorm = Principal{ID: 78271873, Login: "nullorm", Type: "User"}
+
+func TestSignAppendsTheCommenterAndCommitsToTheBaseBranch(t *testing.T) {
+	gh := signable()
+	if err := newSigner(gh, nullorm).sign(t.Context()); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	// The base branch, never the head: the token cannot push to a fork, which is
+	// the case the gate exists for.
+	if gh.putBranch != "main" {
+		t.Errorf("committed to %q, want main", gh.putBranch)
+	}
+	if gh.putFile == nil || len(gh.putFile.Signatures) != 1 {
+		t.Fatalf("wrote %+v, want one entry", gh.putFile)
+	}
+	got := gh.putFile.Signatures[0]
+	if got.ID != 78271873 || got.Login != "nullorm" || got.CLA != "v1" {
+		t.Errorf("entry = %+v, want nullorm at v1", got)
+	}
+	if got.Date != "2026-08-30" {
+		t.Errorf("date = %q, want the run's UTC date", got.Date)
+	}
+	if gh.rerunID != 991 {
+		t.Errorf("rerun id = %d, want the CLA run re-run", gh.rerunID)
+	}
+}
+
+// A conflict means another signature landed between the read and the write, so
+// the signer re-reads and appends to the file as it now stands.
+func TestSignRetriesOnceOnAConflict(t *testing.T) {
+	gh := signable()
+	gh.putConflicts = 1
+	if err := newSigner(gh, nullorm).sign(t.Context()); err != nil {
+		t.Fatalf("sign after one conflict: %v", err)
+	}
+	if gh.putAttempts != 2 {
+		t.Errorf("put attempts = %d, want 2", gh.putAttempts)
+	}
+}
+
+// Two in a row is not congestion, it is a bug, and spinning would hold the runner
+// while making it worse.
+func TestSignGivesUpAfterASecondConflict(t *testing.T) {
+	gh := signable()
+	gh.putConflicts = 2
+	if err := newSigner(gh, nullorm).sign(t.Context()); err == nil {
+		t.Fatal("sign returned nil after repeated conflicts")
+	}
+	if gh.putAttempts != 2 {
+		t.Errorf("put attempts = %d, want 2", gh.putAttempts)
+	}
+}
+
+func TestSignRefusesAStrangerAndWritesNothing(t *testing.T) {
+	gh := signable()
+	err := newSigner(gh, Principal{ID: 999, Login: "carol", Type: "User"}).sign(t.Context())
+	if !errors.Is(err, errNotAPrincipal) {
+		t.Fatalf("sign for a stranger = %v, want errNotAPrincipal", err)
+	}
+	if gh.putAttempts != 0 {
+		t.Errorf("wrote despite refusing: %d attempts", gh.putAttempts)
+	}
+	if len(gh.posted) != 1 || !strings.Contains(gh.posted[0].Body, "@carol") {
+		t.Errorf("no reply naming the commenter: %+v", gh.posted)
+	}
+}
+
+// A double /sign must not paint the pull request red: the signature is there, so
+// the job is green and the reply just says so.
+func TestSignIsGreenAndSilentWhenAlreadySigned(t *testing.T) {
+	gh := signable()
+	gh.files["main"] = &SignatureFile{CLAVersion: "v1", Signatures: []Signature{
+		{Login: "nullorm", ID: 78271873, Date: "2026-08-30", CLA: "v1"},
+	}}
+	if err := newSigner(gh, nullorm).sign(t.Context()); err != nil {
+		t.Fatalf("sign when already signed = %v, want nil", err)
+	}
+	if gh.putAttempts != 0 {
+		t.Errorf("wrote a duplicate: %d attempts", gh.putAttempts)
+	}
+	if len(gh.posted) != 1 {
+		t.Fatalf("posted %d replies, want 1", len(gh.posted))
+	}
+}
+
+// A truncated commit list would drop principals and refuse someone who really is
+// one, so it is a fault rather than a refusal.
+func TestSignRefusesToActOnATruncatedCommitList(t *testing.T) {
+	gh := signable()
+	gh.pr.Commits = 3
+	err := newSigner(gh, nullorm).sign(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "commits") {
+		t.Fatalf("sign on a truncated list = %v, want a commit-count error", err)
+	}
+	if gh.putAttempts != 0 {
+		t.Errorf("wrote on an untrusted principal list: %d attempts", gh.putAttempts)
 	}
 }

--- a/tools/cla/gate/sign_test.go
+++ b/tools/cla/gate/sign_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -61,4 +62,84 @@ func TestLoadSignConfigRejectsWhatItCannotTrust(t *testing.T) {
 			t.Fatal("loadSignConfig accepted a zero commenter id")
 		}
 	})
+}
+
+func TestMaySignRefusesANonPrincipal(t *testing.T) {
+	people := []Principal{{ID: 876188, Login: "poluruprvn", Type: "User"}}
+	head := &SignatureFile{CLAVersion: "v1"}
+	onBase := &SignatureFile{CLAVersion: "v1"}
+
+	err := maySign(Principal{ID: 999, Login: "carol", Type: "User"}, people, head, onBase, "v1")
+	if !errors.Is(err, errNotAPrincipal) {
+		t.Fatalf("maySign for a stranger = %v, want errNotAPrincipal", err)
+	}
+}
+
+// The whole point of signing by comment: a co-author can sign in the pull request
+// they co-wrote instead of opening a throwaway one of their own.
+func TestMaySignAcceptsACoAuthor(t *testing.T) {
+	people := []Principal{
+		{ID: 876188, Login: "poluruprvn", Type: "User"},
+		{ID: 78271873, Login: "nullorm", Type: "User"},
+	}
+	head := &SignatureFile{CLAVersion: "v1"}
+	onBase := &SignatureFile{CLAVersion: "v1"}
+
+	if err := maySign(Principal{ID: 78271873, Login: "nullorm", Type: "User"}, people, head, onBase, "v1"); err != nil {
+		t.Fatalf("maySign for a co-author = %v, want nil", err)
+	}
+}
+
+func TestMaySignRefusesSomeoneAlreadySignedOnTheBaseBranch(t *testing.T) {
+	people := []Principal{{ID: 78271873, Login: "nullorm", Type: "User"}}
+	head := &SignatureFile{CLAVersion: "v1"}
+	onBase := &SignatureFile{CLAVersion: "v1", Signatures: []Signature{
+		{Login: "nullorm", ID: 78271873, Date: "2026-09-01", CLA: "v1"},
+	}}
+
+	err := maySign(Principal{ID: 78271873, Login: "nullorm", Type: "User"}, people, head, onBase, "v1")
+	if !errors.Is(err, errAlreadySigned) {
+		t.Fatalf("maySign for a signed contributor = %v, want errAlreadySigned", err)
+	}
+}
+
+// A signature already in the pull request's own head counts too. Writing a second
+// one would put the id in the file twice once the branch merges the base, and
+// validate() rejects a repeated id and version outright — failing the gate for
+// the crime of signing enthusiastically.
+func TestMaySignRefusesSomeoneAlreadySignedInHead(t *testing.T) {
+	people := []Principal{{ID: 78271873, Login: "nullorm", Type: "User"}}
+	head := &SignatureFile{CLAVersion: "v1", Signatures: []Signature{
+		{Login: "nullorm", ID: 78271873, Date: "2026-09-01", CLA: "v1"},
+	}}
+	onBase := &SignatureFile{CLAVersion: "v1"}
+
+	err := maySign(Principal{ID: 78271873, Login: "nullorm", Type: "User"}, people, head, onBase, "v1")
+	if !errors.Is(err, errAlreadySigned) {
+		t.Fatalf("maySign for a contributor signed in head = %v, want errAlreadySigned", err)
+	}
+}
+
+// A signature at a retired version is not a signature at the one in force.
+func TestMaySignAcceptsSomeoneSignedOnlyAtAnOlderVersion(t *testing.T) {
+	people := []Principal{{ID: 78271873, Login: "nullorm", Type: "User"}}
+	head := &SignatureFile{CLAVersion: "v2"}
+	onBase := &SignatureFile{CLAVersion: "v2", Signatures: []Signature{
+		{Login: "nullorm", ID: 78271873, Date: "2026-08-31", CLA: "v1"},
+	}}
+
+	if err := maySign(Principal{ID: 78271873, Login: "nullorm", Type: "User"}, people, head, onBase, "v2"); err != nil {
+		t.Fatalf("maySign at a bumped version = %v, want nil", err)
+	}
+}
+
+func TestMaySignRefusesABot(t *testing.T) {
+	people := []Principal{{ID: 49699333, Login: "dependabot[bot]", Type: "Bot"}}
+	head := &SignatureFile{CLAVersion: "v1"}
+	onBase := &SignatureFile{CLAVersion: "v1"}
+
+	err := maySign(Principal{ID: 49699333, Login: "dependabot[bot]", Type: "Bot"}, people, head, onBase, "v1")
+	if !errors.Is(err, errBotCommenter) {
+		t.Fatalf("maySign for a bot = %v, want errBotCommenter", err)
+	}
 }

--- a/tools/cla/gate/sign_test.go
+++ b/tools/cla/gate/sign_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestLoadSignConfigReadsTheCommenter(t *testing.T) {
+	t.Setenv("GITHUB_REPOSITORY", "pug-sh/pug")
+	t.Setenv("PR_NUMBER", "107")
+	t.Setenv("COMMENTER_ID", "78271873")
+	t.Setenv("COMMENTER_LOGIN", "nullorm")
+	t.Setenv("COMMENTER_TYPE", "User")
+	t.Setenv("GH_TOKEN", "token")
+
+	cfg, err := loadSignConfig()
+	if err != nil {
+		t.Fatalf("loadSignConfig: %v", err)
+	}
+	if cfg.commenter.ID != 78271873 || cfg.commenter.Login != "nullorm" {
+		t.Errorf("commenter = %+v, want nullorm/78271873", cfg.commenter)
+	}
+	if cfg.pr != 107 {
+		t.Errorf("pr = %d, want 107", cfg.pr)
+	}
+	if cfg.repo != "pug-sh/pug" {
+		t.Errorf("repo = %q, want pug-sh/pug", cfg.repo)
+	}
+}
+
+// Every one of these weakens the signer if it is missing rather than wrong: a
+// zero id names nobody, and an empty token downgrades the run to the
+// unauthenticated rate limit and then fails the write with a 401.
+func TestLoadSignConfigRejectsWhatItCannotTrust(t *testing.T) {
+	base := map[string]string{
+		"GITHUB_REPOSITORY": "pug-sh/pug",
+		"PR_NUMBER":         "107",
+		"COMMENTER_ID":      "78271873",
+		"COMMENTER_LOGIN":   "nullorm",
+		"COMMENTER_TYPE":    "User",
+		"GH_TOKEN":          "token",
+	}
+	for _, blank := range []string{"GITHUB_REPOSITORY", "COMMENTER_LOGIN", "GH_TOKEN"} {
+		t.Run(blank, func(t *testing.T) {
+			for k, v := range base {
+				t.Setenv(k, v)
+			}
+			t.Setenv("GITHUB_TOKEN", "")
+			t.Setenv(blank, "")
+			if _, err := loadSignConfig(); err == nil {
+				t.Fatalf("loadSignConfig accepted an empty %s", blank)
+			}
+		})
+	}
+
+	t.Run("zero commenter id", func(t *testing.T) {
+		for k, v := range base {
+			t.Setenv(k, v)
+		}
+		t.Setenv("COMMENTER_ID", "0")
+		if _, err := loadSignConfig(); err == nil {
+			t.Fatal("loadSignConfig accepted a zero commenter id")
+		}
+	})
+}


### PR DESCRIPTION
Contributors can sign the CLA by commenting `/sign` on a pull request they have
work in, instead of hand-editing `tools/cla/signatures.json` and pushing.

## Why the signature goes to the base branch

`GITHUB_TOKEN` cannot push to a fork, even with `maintainer_can_modify` — and a
fork is the case the CLA gate exists for. So the signer commits to the base
branch and the checker learns to look there, rather than committing to the pull
request's head.

The contributor is the **commit author** (`<id>+<login>@users.noreply.github.com`)
and the Actions bot is the committer, so the record still lives in git history
under the identity that agreed to it — the property `cla.yaml` states.

## Why a comment can execute the agreement

A comment's author is the one identity in this flow GitHub attests. A commit's
author, its committer and a `Co-authored-by:` trailer are all self-asserted, which
is exactly why `appendOnly` refuses to take a signature from any of them. A
comment carries no such doubt, so it is accepted from **anyone with work in the
pull request** — which means a co-author can now sign in place instead of opening
a throwaway pull request of their own.

## The checker change

Two edits, and the blast radius is one pull request per contributor:

- The in-force file is read at `cfg.baseRef`, **not** `cfg.baseSHA`. That SHA is
  pinned in the event payload and a workflow re-run replays it, so a signature
  committed after the event fired would have been invisible on exactly the re-run
  that needs to see it.
- `unsigned()` treats a principal as signed if they appear at the version in force
  in `head` **or** on the base branch.

`appendOnly` is untouched — it compares against the merge base, which does not
gain the entry either, so a signature landing on `main` is never misread as one
this pull request deleted.

| | head has it? | needs the new lookup? |
|---|---|---|
| First pull request, signed via `/sign` | no — it landed on the base branch | **yes** |
| Same one after any rebase or merge | yes | no |
| Every later pull request | yes | no |

## Refusals

Checked in this order — whichever fires is the only message the contributor reads:

1. **Bot** — holds no copyright, so nothing to license.
2. **Already signed** — replies and exits **green**; a double `/sign` should not
   paint the pull request red when the signature is right there.
3. **Not a principal** — the only security-relevant check, and the one never
   softened.

## Notes for review

- The workflow's `if:` is a **prefilter**, not the match. Actions expressions have
  no `trim()`, so an exact `==` would silently swallow `/sign ` and `/sign\r\n` —
  no job, no reply, no clue why. The authoritative match is in Go after
  `TrimSpace`; a near-miss exits 0 without commenting.
- `resolveCoauthors` moved from a method on `*checker` to a function over
  `githubAPI`, so the signer and the checker provably share one definition of
  "who is a principal".
- `actions: write` is a real escalation on a comment-triggered workflow. It is
  bounded by the workflow file living on the default branch.
- **`CLA.md` §"How to sign" is amended.** My read is that this does **not** warrant
  a `v2` bump — it changes the mechanism of assent, not the grant, and a bump would
  force both existing signatories to re-sign for no change in what they granted.
  That is a legal call, not a technical one; it is the main thing I would like a
  second opinion on.
- **`pr.State` is decoded but unused** — signing on a *closed* pull request still
  attempts the re-run rather than skipping it. Harmless, but it is a deliberate
  omission rather than an oversight.

## Testing

99 tests pass; `gofmt` and `go vet` clean. Coverage is against fakes and
`httptest` — the `issue_comment` trigger, the contents `PUT` and the re-run call
have **not** been exercised against real GitHub, and can only really be validated
by firing this on a live pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
