### PR TITLE
Feat/billing store

### DIFF
--- a/internal/core/billing/billing.go
+++ b/internal/core/billing/billing.go
@@ -153,7 +153,9 @@ func contractLapsed(rec Record, now time.Time) bool {
 // operator types — into the instant to store. The comparison above is half-open,
 // so storing that day's midnight would lapse the plan at the start of it. The
 // date is read in lastDay's own location, so a picker in any zone means the day
-// it displayed.
+// it displayed. The boundary itself is UTC midnight, like every window in this
+// subsystem; building it in lastDay's zone would store a different instant per
+// operator.
 func ContractEndExclusive(lastDay time.Time) time.Time {
 	y, m, d := lastDay.Date()
 	return time.Date(y, m, d+1, 0, 0, 0, 0, time.UTC)

--- a/internal/core/billing/config.go
+++ b/internal/core/billing/config.go
@@ -1,0 +1,8 @@
+package billing
+
+// Config is the whole billing switch. Off means every org resolves with no quota
+// at all, so no client can render a limit that does not apply. Declared here, not
+// in the server, so `pug billing` can read it without importing the server.
+type Config struct {
+	Enabled bool `env:"PUG_BILLING_ENABLED,default=false"`
+}

--- a/internal/core/billing/floors_test.go
+++ b/internal/core/billing/floors_test.go
@@ -1,0 +1,27 @@
+package billing
+
+import "testing"
+
+// The real catalog always has both floors, so the guard would otherwise never
+// run. Swaps the catalog for its duration, hence living inside the package.
+func TestNewServiceRefusesACatalogMissingAFloor(t *testing.T) {
+	for _, missing := range []string{SlugFree, SlugTrial} {
+		t.Run(missing, func(t *testing.T) {
+			original := catalog
+			t.Cleanup(func() { catalog = original })
+
+			trimmed := make([]Plan, 0, len(original))
+			for _, p := range original {
+				if p.Slug != missing {
+					trimmed = append(trimmed, p)
+				}
+			}
+			catalog = trimmed
+
+			// Construction never touches the pools, so nil reaches the check.
+			if _, err := NewService(nil, nil, true); err == nil {
+				t.Fatalf("NewService accepted a catalog with no %q tier", missing)
+			}
+		})
+	}
+}

--- a/internal/core/billing/guards_test.go
+++ b/internal/core/billing/guards_test.go
@@ -1,0 +1,289 @@
+package billing_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	corebilling "github.com/pug-sh/pug/internal/core/billing"
+	"github.com/pug-sh/pug/internal/gen/repo/dbwrite"
+)
+
+func TestAnchorDayOutOfRangeIsRefused(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	// 65537 truncates to 1 as an int16, so an unchecked write would store a
+	// plausible day and report success.
+	for _, day := range []int{32, 65537, -1} {
+		_, err := f.svc.SetPlan(t.Context(), f.orgID, actor, corebilling.Change{
+			PlanSlug:  "growth",
+			AnchorDay: new(day),
+		})
+		if !errors.Is(err, corebilling.ErrAnchorDayRange) {
+			t.Errorf("anchor day %d: err = %v, want ErrAnchorDayRange", day, err)
+		}
+	}
+}
+
+func TestExtendTrialIsRefusedOnAGrantedPlan(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	if _, err := f.svc.SetPlan(t.Context(), f.orgID, actor, corebilling.Change{
+		PlanSlug: "growth",
+	}); err != nil {
+		t.Fatalf("set growth: %v", err)
+	}
+
+	// A granted plan resolves ahead of any trial date, so the write would store a
+	// date that changes nothing and still print as a success.
+	_, err := f.svc.ExtendTrial(t.Context(), f.orgID, actor, 30, time.Now())
+	if !errors.Is(err, corebilling.ErrTrialOnGrantedPlan) {
+		t.Errorf("err = %v, want ErrTrialOnGrantedPlan", err)
+	}
+}
+
+// A slug the catalog has dropped resolves free without ever consulting a trial
+// date, so extending one would store a date that changes nothing — the same
+// silent success the guard above exists to prevent.
+func TestExtendTrialIsRefusedOnAnUnknownPlan(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	// Past SetPlan, which rejects the slug: only a catalog removal produces this.
+	if _, err := f.pg.PgW.Exec(t.Context(),
+		"insert into billing_entitlements (org_id, plan_slug) values ($1, 'growth-v0')", f.orgID); err != nil {
+		t.Fatalf("seed an unknown slug: %v", err)
+	}
+
+	_, err := f.svc.ExtendTrial(t.Context(), f.orgID, actor, 30, time.Now())
+	if !errors.Is(err, corebilling.ErrTrialOnGrantedPlan) {
+		t.Errorf("err = %v, want ErrTrialOnGrantedPlan", err)
+	}
+}
+
+// "Extend" is measured from now, so a small --days on a trial with longer to run
+// would shorten it. The fixture org is long past its derived trial, so this sets
+// a live one first.
+func TestExtendTrialWillNotShortenOne(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	now := time.Now()
+	if _, err := f.svc.ExtendTrial(t.Context(), f.orgID, actor, 30, now); err != nil {
+		t.Fatalf("extend to 30 days: %v", err)
+	}
+
+	_, err := f.svc.ExtendTrial(t.Context(), f.orgID, actor, 3, now)
+	if !errors.Is(err, corebilling.ErrTrialNotExtended) {
+		t.Errorf("err = %v, want ErrTrialNotExtended; a 3-day extend cut a 30-day trial", err)
+	}
+
+	if _, err := f.svc.ExtendTrial(t.Context(), f.orgID, actor, 400, now); !errors.Is(err, corebilling.ErrTrialDaysRange) {
+		t.Errorf("err = %v, want ErrTrialDaysRange", err)
+	}
+}
+
+// The contract belongs to the granted plan, so a downgrade must not leave a
+// future date behind for a dashboard to render as "your Free plan ends...".
+func TestDowngradeToAFloorPlanClearsTheContract(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	until := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := f.svc.SetPlan(t.Context(), f.orgID, actor, corebilling.Change{
+		PlanSlug:       "growth",
+		ContractEndsAt: new(until),
+	}); err != nil {
+		t.Fatalf("set growth: %v", err)
+	}
+
+	rec, err := f.svc.SetPlan(t.Context(), f.orgID, actor, corebilling.Change{PlanSlug: corebilling.SlugFree})
+	if err != nil {
+		t.Fatalf("downgrade: %v", err)
+	}
+	if !rec.ContractEndsAt.IsZero() {
+		t.Errorf("contract_ends_at = %s after downgrading to free, want it cleared", rec.ContractEndsAt)
+	}
+
+	// A comped pilot names its own end date, and that one is kept.
+	pilot, err := f.svc.SetPlan(t.Context(), f.orgID, actor, corebilling.Change{
+		PlanSlug:       corebilling.SlugFree,
+		IncludedEvents: new(int64(5_000_000)),
+		ContractEndsAt: new(until),
+	})
+	if err != nil {
+		t.Fatalf("set comped pilot: %v", err)
+	}
+	if !pilot.ContractEndsAt.Equal(until) {
+		t.Errorf("contract_ends_at = %s, want the pilot's %s", pilot.ContractEndsAt, until)
+	}
+}
+
+func TestClearDistinguishesAnUnknownOrgFromAnEmptyOne(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	if err := f.svc.Clear(t.Context(), f.orgID, actor); !errors.Is(err, corebilling.ErrNoEntitlement) {
+		t.Errorf("clear on an org with no row: err = %v, want ErrNoEntitlement", err)
+	}
+	if err := f.svc.Clear(t.Context(), "o_doesnotexist00000", actor); !errors.Is(err, corebilling.ErrOrgNotFound) {
+		t.Errorf("clear on an unknown org: err = %v, want ErrOrgNotFound", err)
+	}
+}
+
+func TestStoredRecordShowsAnOverrideThatIsNotInForce(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	lapsed := time.Now().Add(-time.Hour)
+	if _, err := f.svc.SetPlan(t.Context(), f.orgID, actor, corebilling.Change{
+		PlanSlug:       "scale",
+		IncludedEvents: new(int64(5_000_000)),
+		ContractEndsAt: new(lapsed),
+		Note:           new("annual wire, INV-123"),
+	}); err != nil {
+		t.Fatalf("set scale: %v", err)
+	}
+
+	ent, err := f.svc.GetEntitlement(t.Context(), f.orgID, time.Now())
+	if err != nil {
+		t.Fatalf("GetEntitlement: %v", err)
+	}
+	if got := ent.IncludedEvents; got == nil || *got != 10_000 {
+		t.Errorf("resolved quota = %v, want the free floor after the contract lapsed", got)
+	}
+
+	// The override the resolved answer hides is the one that carries onto the next
+	// `set`, so `show` has to print it.
+	rec, err := f.svc.StoredRecord(t.Context(), f.orgID)
+	if err != nil {
+		t.Fatalf("StoredRecord: %v", err)
+	}
+	if rec.IncludedEventsOverride != 5_000_000 {
+		t.Errorf("stored override = %d, want 5000000", rec.IncludedEventsOverride)
+	}
+	if rec.Note != "annual wire, INV-123" {
+		t.Errorf("stored note = %q, want it readable from the current row", rec.Note)
+	}
+}
+
+// The atomicity the design leans on: a change and its history row commit together
+// or not at all. Forced by an actor longer than history.actor's varchar(150), so
+// the entitlement upsert succeeds and only the history insert fails.
+func TestAFailedHistoryAppendRollsBackTheChange(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	_, err := f.svc.SetPlan(t.Context(), f.orgID, strings.Repeat("x", 200), corebilling.Change{
+		PlanSlug: "growth",
+	})
+	if err == nil {
+		t.Fatal("SetPlan with an over-long actor: err = nil, want the history insert to fail")
+	}
+
+	var rows int
+	if err := f.pg.PgRO.QueryRow(t.Context(),
+		"select count(*) from billing_entitlements where org_id = $1", f.orgID).Scan(&rows); err != nil {
+		t.Fatalf("count entitlements: %v", err)
+	}
+	if rows != 0 {
+		t.Errorf("%d entitlement rows survived a failed history append, want 0", rows)
+	}
+}
+
+// The mirror of the contract clear: converting a trial to a paid tier must drop
+// the stored trial date, or a later downgrade to free resurrects it and the org
+// resolves TRIALING on the trial's much larger quota.
+func TestConvertingATrialToAPaidPlanClearsTheTrialDate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	if _, err := f.svc.ExtendTrial(t.Context(), f.orgID, actor, 90, time.Now()); err != nil {
+		t.Fatalf("extend trial: %v", err)
+	}
+
+	converted, err := f.svc.SetPlan(t.Context(), f.orgID, actor, corebilling.Change{PlanSlug: "growth"})
+	if err != nil {
+		t.Fatalf("convert to growth: %v", err)
+	}
+	if !converted.TrialEndsAt.IsZero() {
+		t.Errorf("trial_ends_at = %s after converting to growth, want it cleared", converted.TrialEndsAt)
+	}
+
+	// The date must stay gone through a later downgrade, which is where a stale
+	// one would actually bite.
+	back, err := f.svc.SetPlan(t.Context(), f.orgID, actor, corebilling.Change{PlanSlug: corebilling.SlugFree})
+	if err != nil {
+		t.Fatalf("downgrade: %v", err)
+	}
+	if !back.TrialEndsAt.IsZero() {
+		t.Fatalf("trial_ends_at = %s after downgrading, want it cleared", back.TrialEndsAt)
+	}
+	ent, err := f.svc.GetEntitlement(t.Context(), f.orgID, time.Now())
+	if err != nil {
+		t.Fatalf("GetEntitlement: %v", err)
+	}
+	if ent.Status != corebilling.StatusFree {
+		t.Errorf("status = %s, want FREE; a stale trial date restored a trial quota", ent.Status)
+	}
+}
+
+// Clear takes the same org lock mutate does. Without it a concurrent SetPlan can
+// insert between the delete and the commit, leaving a stored entitlement whose
+// newest history entry says it was cleared.
+func TestClearTakesTheOrgLock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	if _, err := f.svc.SetPlan(t.Context(), f.orgID, actor, corebilling.Change{PlanSlug: "growth"}); err != nil {
+		t.Fatalf("set growth: %v", err)
+	}
+
+	tx, err := f.pg.PgW.Begin(t.Context())
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _ = tx.Rollback(t.Context()) }()
+	if err := dbwrite.New(tx).LockBillingEntitlementOrg(t.Context(), f.orgID); err != nil {
+		t.Fatalf("lock: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- f.svc.Clear(t.Context(), f.orgID, actor) }()
+
+	select {
+	case err := <-done:
+		t.Fatalf("Clear finished (%v) while the org lock was held; it is not taking the lock", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	if err := tx.Rollback(t.Context()); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("Clear after the lock was released: %v", err)
+	}
+}

--- a/internal/core/billing/guards_test.go
+++ b/internal/core/billing/guards_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	corebilling "github.com/pug-sh/pug/internal/core/billing"
 	"github.com/pug-sh/pug/internal/gen/repo/dbwrite"
@@ -378,6 +379,18 @@ func TestOverLongDisplayNameIsRefused(t *testing.T) {
 	})
 	if !errors.Is(err, corebilling.ErrDisplayNameLong) {
 		t.Errorf("err = %v, want ErrDisplayNameLong", err)
+	}
+
+	// varchar(150) bounds characters, so a multi-byte name at the limit fits.
+	rec, err := f.svc.SetPlan(t.Context(), f.orgID, actor, corebilling.Change{
+		PlanSlug:    "growth",
+		DisplayName: new(strings.Repeat("\u00e9", corebilling.MaxDisplayNameLen)),
+	})
+	if err != nil {
+		t.Fatalf("set plan with a 150-character non-ASCII name: %v", err)
+	}
+	if got := utf8.RuneCountInString(rec.DisplayNameOverride); got != corebilling.MaxDisplayNameLen {
+		t.Errorf("stored name = %d characters, want %d", got, corebilling.MaxDisplayNameLen)
 	}
 }
 

--- a/internal/core/billing/guards_test.go
+++ b/internal/core/billing/guards_test.go
@@ -287,3 +287,134 @@ func TestClearTakesTheOrgLock(t *testing.T) {
 		t.Fatalf("Clear after the lock was released: %v", err)
 	}
 }
+
+// The contract is what expires an override, so clearing it on a downgrade has to
+// take the overrides with it — otherwise the deal a lapse would have ended
+// becomes permanent, and "downgrade to free" leaves a larger quota than doing
+// nothing at all.
+func TestDowngradeToAFloorPlanEndsTheOverrides(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	ctx := t.Context()
+	now := time.Now()
+	until := now.AddDate(0, 1, 0)
+
+	if _, err := f.svc.SetPlan(ctx, f.orgID, actor, corebilling.Change{
+		PlanSlug:       "growth",
+		IncludedEvents: new(int64(5_000_000)),
+		DisplayName:    new("Acme Enterprise"),
+		ContractEndsAt: new(until),
+	}); err != nil {
+		t.Fatalf("set the deal: %v", err)
+	}
+
+	if _, err := f.svc.SetPlan(ctx, f.orgID, actor, corebilling.Change{PlanSlug: corebilling.SlugFree}); err != nil {
+		t.Fatalf("downgrade: %v", err)
+	}
+
+	ent, err := f.svc.GetEntitlement(ctx, f.orgID, until.AddDate(5, 0, 0))
+	if err != nil {
+		t.Fatalf("GetEntitlement: %v", err)
+	}
+	if got := ent.IncludedEvents; got == nil || *got != 10_000 {
+		t.Errorf("quota five years after the downgrade = %v, want the free floor's 10000", got)
+	}
+	if ent.DisplayName != "Free" {
+		t.Errorf("display name = %q, want the free floor's, not the deal's", ent.DisplayName)
+	}
+
+	// A comped grant on the floor names its own terms, and those survive.
+	pilot, err := f.svc.SetPlan(ctx, f.orgID, actor, corebilling.Change{
+		PlanSlug:       corebilling.SlugFree,
+		IncludedEvents: new(int64(5_000_000)),
+		ContractEndsAt: new(until),
+	})
+	if err != nil {
+		t.Fatalf("set comped pilot: %v", err)
+	}
+	if pilot.IncludedEventsOverride != 5_000_000 {
+		t.Errorf("pilot quota = %d, want the named 5000000", pilot.IncludedEventsOverride)
+	}
+}
+
+// The other way to store a trial date that resolves to nothing: the trial branch
+// is gated on the contract, so a lapsed one swallows the extension exactly as a
+// granted plan would.
+func TestExtendTrialIsRefusedOnALapsedContract(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	now := time.Now()
+	if _, err := f.svc.SetPlan(t.Context(), f.orgID, actor, corebilling.Change{
+		PlanSlug:       corebilling.SlugFree,
+		IncludedEvents: new(int64(5_000_000)),
+		ContractEndsAt: new(now.Add(-time.Hour)),
+	}); err != nil {
+		t.Fatalf("set an ended pilot: %v", err)
+	}
+
+	_, err := f.svc.ExtendTrial(t.Context(), f.orgID, actor, 30, now)
+	if !errors.Is(err, corebilling.ErrTrialOnLapsedContract) {
+		t.Errorf("err = %v, want ErrTrialOnLapsedContract", err)
+	}
+}
+
+// An operator's display name is free text, and varchar(150) would otherwise
+// surface as a raw SQLSTATE logged as a pug fault.
+func TestOverLongDisplayNameIsRefused(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	_, err := f.svc.SetPlan(t.Context(), f.orgID, actor, corebilling.Change{
+		PlanSlug:    "growth",
+		DisplayName: new(strings.Repeat("x", corebilling.MaxDisplayNameLen+1)),
+	})
+	if !errors.Is(err, corebilling.ErrDisplayNameLong) {
+		t.Errorf("err = %v, want ErrDisplayNameLong", err)
+	}
+}
+
+// The lock mutate takes before its read, which is the one `for update` cannot
+// stand in for: it locks nothing when the org has no row yet, so without this two
+// concurrent first writes both read an empty record and the second wins.
+func TestSetPlanTakesTheOrgLock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	tx, err := f.pg.PgW.Begin(t.Context())
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _ = tx.Rollback(t.Context()) }()
+	if err := dbwrite.New(tx).LockBillingEntitlementOrg(t.Context(), f.orgID); err != nil {
+		t.Fatalf("lock: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := f.svc.SetPlan(t.Context(), f.orgID, actor, corebilling.Change{PlanSlug: "growth"})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("SetPlan finished (%v) while the org lock was held; it is not taking the lock", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	if err := tx.Rollback(t.Context()); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("SetPlan after the lock was released: %v", err)
+	}
+}

--- a/internal/core/billing/integration_test.go
+++ b/internal/core/billing/integration_test.go
@@ -252,12 +252,17 @@ func TestEveryCatalogSlugIsStorable(t *testing.T) {
 
 	f := newFixture(t)
 	for _, plan := range corebilling.Plans() {
+		if plan.Slug == corebilling.SlugTrial {
+			continue // not settable by design; ExtendTrial owns it
+		}
+		if plan.Retired {
+			// One org holds every slug in turn, and a retired tier is grantable only to
+			// the org already on it. retired_test.go stores one on its incumbent.
+			continue
+		}
 		change := corebilling.Change{PlanSlug: plan.Slug}
 		if plan.Slug == corebilling.SlugCustom {
 			change.IncludedEvents = new(int64(1))
-		}
-		if plan.Slug == corebilling.SlugTrial {
-			continue // not settable by design; ExtendTrial owns it
 		}
 		if _, err := f.svc.SetPlan(t.Context(), f.orgID, actor, change); err != nil {
 			t.Errorf("%s: %v — this catalog slug is not storable", plan.Slug, err)

--- a/internal/core/billing/integration_test.go
+++ b/internal/core/billing/integration_test.go
@@ -1,0 +1,449 @@
+package billing_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	corebilling "github.com/pug-sh/pug/internal/core/billing"
+	coreusage "github.com/pug-sh/pug/internal/core/usage"
+	"github.com/pug-sh/pug/internal/gen/repo/dbwrite"
+	"github.com/pug-sh/pug/internal/testutil"
+	"github.com/rs/xid"
+)
+
+const actor = "tester@localhost"
+
+type fixture struct {
+	svc   *corebilling.Service
+	pg    *testutil.TestPostgres
+	orgID string
+}
+
+// Orgs are backdated well past the trial so a test asserting a granted plan is
+// not also fighting a live trial window.
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	pg := testutil.SetupPostgres(t)
+
+	org, err := dbwrite.New(pg.PgW).CreateOrg(t.Context(), dbwrite.CreateOrgParams{
+		ID:          xid.New().String(),
+		DisplayName: "acme",
+	})
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	testutil.SetOrgCreateTime(t, pg.PgW, org.ID, time.Date(2025, 3, 10, 0, 0, 0, 0, time.UTC))
+
+	svc, err := corebilling.NewService(pg.PgRO, pg.PgW, true)
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	return &fixture{
+		svc:   svc,
+		pg:    pg,
+		orgID: org.ID,
+	}
+}
+
+func TestOrgWithNoRowResolvesFromItsAgeAndWritesNothing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	ent, err := f.svc.GetEntitlement(t.Context(), f.orgID, time.Now())
+	if err != nil {
+		t.Fatalf("GetEntitlement: %v", err)
+	}
+	if ent.Status != corebilling.StatusFree || ent.Slug != corebilling.SlugFree {
+		t.Errorf("status/slug = %s/%s, want FREE/free for an org past its trial", ent.Status, ent.Slug)
+	}
+
+	// A read must not materialize a row: "no row" is the normal state, and one
+	// appearing here would make the trial stored rather than derived.
+	var rows int
+	if err := f.pg.PgRO.QueryRow(t.Context(),
+		"select count(*) from billing_entitlements where org_id = $1", f.orgID).Scan(&rows); err != nil {
+		t.Fatalf("count entitlements: %v", err)
+	}
+	if rows != 0 {
+		t.Errorf("a read created %d entitlement rows, want 0", rows)
+	}
+}
+
+// The assertion that matters most in this slice: the window billing reports and
+// the window the meter sums are the same one. A client renders "X of Y" from two
+// separate RPCs, so a divergence here makes both numbers individually correct and
+// the sentence wrong.
+func TestQuotaWindowMatchesTheMeters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	ctx := t.Context()
+	meter := coreusage.NewService(f.pg.PgRO, f.pg.PgW)
+
+	for _, tc := range []struct {
+		name   string
+		anchor int
+	}{
+		{"derived from the signup day", 0},
+		{"an explicit mid-month anchor", 22},
+		{"an anchor that clamps in short months", 31},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			change := corebilling.Change{PlanSlug: "growth"}
+			if tc.anchor > 0 {
+				change.AnchorDay = new(tc.anchor)
+			}
+			if _, err := f.svc.SetPlan(ctx, f.orgID, actor, change); err != nil {
+				t.Fatalf("SetPlan: %v", err)
+			}
+
+			// Every month of a year, so a clamped February is covered rather than
+			// whichever month the suite happens to run in.
+			for month := time.January; month <= time.December; month++ {
+				now := time.Date(2026, month, 14, 9, 30, 0, 0, time.UTC)
+
+				ent, err := f.svc.GetEntitlement(ctx, f.orgID, now)
+				if err != nil {
+					t.Fatalf("GetEntitlement: %v", err)
+				}
+				meterStart, meterEnd, err := meter.GetOrgPeriod(ctx, f.orgID, now)
+				if err != nil {
+					t.Fatalf("GetOrgPeriod: %v", err)
+				}
+				if !ent.PeriodStart.Equal(meterStart) || !ent.PeriodEnd.Equal(meterEnd) {
+					t.Fatalf("%s: billing window [%s, %s) != meter window [%s, %s)",
+						month, ent.PeriodStart, ent.PeriodEnd, meterStart, meterEnd)
+				}
+			}
+		})
+	}
+}
+
+func TestGetEntitlementReportsAnUnknownOrg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	_, err := f.svc.GetEntitlement(t.Context(), xid.New().String(), time.Now())
+	if !errors.Is(err, corebilling.ErrOrgNotFound) {
+		t.Errorf("err = %v, want ErrOrgNotFound", err)
+	}
+}
+
+func TestSetPlanRoundTrips(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	ctx := t.Context()
+	until := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	if _, err := f.svc.SetPlan(ctx, f.orgID, actor, corebilling.Change{
+		PlanSlug:       "growth",
+		ContractEndsAt: new(until),
+		Note:           new("annual wire, INV-123"),
+	}); err != nil {
+		t.Fatalf("SetPlan: %v", err)
+	}
+
+	ent, err := f.svc.GetEntitlement(ctx, f.orgID, time.Now())
+	if err != nil {
+		t.Fatalf("GetEntitlement: %v", err)
+	}
+	if ent.Status != corebilling.StatusActive || ent.Slug != "growth" {
+		t.Errorf("status/slug = %s/%s, want ACTIVE/growth", ent.Status, ent.Slug)
+	}
+	if ent.IncludedEvents == nil || *ent.IncludedEvents != 500_000 {
+		t.Errorf("quota = %v, want the catalog's 500000", ent.IncludedEvents)
+	}
+	if !ent.ContractEndsAt.Equal(until) {
+		t.Errorf("contract_ends_at = %s, want %s", ent.ContractEndsAt, until)
+	}
+}
+
+// The reason un-passed flags leave stored values alone: the common re-set is a
+// renewal, and reverting a negotiated quota to a catalog number would be silent.
+func TestReSetKeepsUnmentionedOverrides(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	ctx := t.Context()
+
+	if _, err := f.svc.SetPlan(ctx, f.orgID, actor, corebilling.Change{
+		PlanSlug:       corebilling.SlugCustom,
+		IncludedEvents: new(int64(5_000_000)),
+		DisplayName:    new("Acme Enterprise"),
+		AnchorDay:      new(17),
+	}); err != nil {
+		t.Fatalf("SetPlan: %v", err)
+	}
+
+	// A renewal: a new end date and nothing else.
+	rec, err := f.svc.SetPlan(ctx, f.orgID, actor, corebilling.Change{
+		PlanSlug:       corebilling.SlugCustom,
+		ContractEndsAt: new(time.Date(2028, 1, 1, 0, 0, 0, 0, time.UTC)),
+	})
+	if err != nil {
+		t.Fatalf("renewal SetPlan: %v", err)
+	}
+	if rec.IncludedEventsOverride != 5_000_000 {
+		t.Errorf("quota after a renewal = %d, want the negotiated 5000000 preserved", rec.IncludedEventsOverride)
+	}
+	if rec.DisplayNameOverride != "Acme Enterprise" {
+		t.Errorf("name after a renewal = %q, want it preserved", rec.DisplayNameOverride)
+	}
+	if rec.AnchorDay != 17 {
+		t.Errorf("anchor day after a renewal = %d, want it preserved", rec.AnchorDay)
+	}
+
+	// And an explicit clear really clears.
+	cleared, err := f.svc.SetPlan(ctx, f.orgID, actor, corebilling.Change{
+		PlanSlug:       "growth",
+		IncludedEvents: new(int64),
+		DisplayName:    new(string),
+	})
+	if err != nil {
+		t.Fatalf("clearing SetPlan: %v", err)
+	}
+	if cleared.IncludedEventsOverride != 0 || cleared.DisplayNameOverride != "" {
+		t.Errorf("cleared overrides = %d/%q, want empty", cleared.IncludedEventsOverride, cleared.DisplayNameOverride)
+	}
+}
+
+// The database is the guard, not the CLI: the row is what every read trusts.
+func TestCustomPlanRequiresAQuota(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	_, err := f.svc.SetPlan(t.Context(), f.orgID, actor, corebilling.Change{PlanSlug: corebilling.SlugCustom})
+	if !errors.Is(err, corebilling.ErrCustomNeedsQuota) {
+		t.Fatalf("err = %v, want ErrCustomNeedsQuota", err)
+	}
+
+	// Straight past the service, to prove the constraint itself holds.
+	_, err = f.pg.PgW.Exec(t.Context(),
+		"insert into billing_entitlements (org_id, plan_slug) values ($1, 'custom')", f.orgID)
+	if err == nil {
+		t.Error("the database accepted a custom entitlement with no quota")
+	} else if !strings.Contains(err.Error(), "billing_entitlements_custom_needs_quota") {
+		t.Errorf("err = %v, want the custom_needs_quota constraint", err)
+	}
+}
+
+// Every slug the Go catalog knows must be storable. There is deliberately no
+// plan_slug check constraint, so this is what catches a slug outgrowing
+// varchar(50) or being rejected by the service.
+func TestEveryCatalogSlugIsStorable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	for _, plan := range corebilling.Plans() {
+		change := corebilling.Change{PlanSlug: plan.Slug}
+		if plan.Slug == corebilling.SlugCustom {
+			change.IncludedEvents = new(int64(1))
+		}
+		if plan.Slug == corebilling.SlugTrial {
+			continue // not settable by design; ExtendTrial owns it
+		}
+		if _, err := f.svc.SetPlan(t.Context(), f.orgID, actor, change); err != nil {
+			t.Errorf("%s: %v — this catalog slug is not storable", plan.Slug, err)
+		}
+	}
+}
+
+// The custom tier is never purchasable, but an operator must be able to grant it
+// to an org that has never held one — that is what a negotiated deal IS.
+func TestCustomPlanIsGrantableToAnyOrg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	if _, err := f.svc.SetPlan(t.Context(), f.orgID, actor, corebilling.Change{
+		PlanSlug:       corebilling.SlugCustom,
+		IncludedEvents: new(int64(5_000_000)),
+	}); err != nil {
+		t.Fatalf("granting a custom deal: %v", err)
+	}
+
+	ent, err := f.svc.GetEntitlement(t.Context(), f.orgID, time.Now())
+	if err != nil {
+		t.Fatalf("GetEntitlement: %v", err)
+	}
+	if ent.IncludedEvents == nil || *ent.IncludedEvents != 5_000_000 {
+		t.Errorf("quota = %v, want the negotiated 5000000", ent.IncludedEvents)
+	}
+}
+
+func TestExtendTrialAndClear(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	ctx := t.Context()
+	now := time.Now()
+
+	if _, err := f.svc.ExtendTrial(ctx, f.orgID, actor, 30, now); err != nil {
+		t.Fatalf("ExtendTrial: %v", err)
+	}
+	ent, err := f.svc.GetEntitlement(ctx, f.orgID, now)
+	if err != nil {
+		t.Fatalf("GetEntitlement: %v", err)
+	}
+	if ent.Status != corebilling.StatusTrialing {
+		t.Errorf("status = %s after extend-trial, want TRIALING", ent.Status)
+	}
+	if got := ent.TrialEndsAt.Sub(now).Hours(); got < 29*24 || got > 31*24 {
+		t.Errorf("trial ends in %.0fh, want about 30 days", got)
+	}
+
+	if err := f.svc.Clear(ctx, f.orgID, actor); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	ent, err = f.svc.GetEntitlement(ctx, f.orgID, now)
+	if err != nil {
+		t.Fatalf("GetEntitlement after clear: %v", err)
+	}
+	if ent.Status != corebilling.StatusFree {
+		t.Errorf("status = %s after clear, want FREE (the org is back on the derived floors)", ent.Status)
+	}
+}
+
+func TestHistoryRecordsEveryChange(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	ctx := t.Context()
+
+	if _, err := f.svc.SetPlan(ctx, f.orgID, actor, corebilling.Change{
+		PlanSlug: "starter", Note: new("first"),
+	}); err != nil {
+		t.Fatalf("SetPlan: %v", err)
+	}
+	if _, err := f.svc.SetPlan(ctx, f.orgID, "someone@else", corebilling.Change{
+		PlanSlug: "scale", Note: new("upgrade"),
+	}); err != nil {
+		t.Fatalf("SetPlan: %v", err)
+	}
+	if err := f.svc.Clear(ctx, f.orgID, actor); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+
+	entries, err := f.svc.History(ctx, f.orgID)
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("history has %d entries, want 3 (two grants and a clear)", len(entries))
+	}
+	// Newest first, and the clear is a snapshot with no values.
+	if entries[0].Record.Present {
+		t.Errorf("the newest entry has values; a clear must record an empty snapshot")
+	}
+	if entries[1].Record.PlanSlug != "scale" || entries[1].Actor != "someone@else" {
+		t.Errorf("entry 1 = %s by %s, want scale by someone@else",
+			entries[1].Record.PlanSlug, entries[1].Actor)
+	}
+	if entries[2].Record.PlanSlug != "starter" || entries[2].Record.Note != "first" {
+		t.Errorf("entry 2 = %s/%q, want starter/first", entries[2].Record.PlanSlug, entries[2].Record.Note)
+	}
+}
+
+// A refused change must leave nothing behind: the row and its history commit
+// together or not at all.
+func TestRejectedChangeAppendsNoHistory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	if _, err := f.svc.SetPlan(t.Context(), f.orgID, actor,
+		corebilling.Change{PlanSlug: corebilling.SlugCustom}); err == nil {
+		t.Fatal("a custom plan with no quota was accepted")
+	}
+
+	entries, err := f.svc.History(t.Context(), f.orgID)
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("history has %d entries after a refused change, want 0", len(entries))
+	}
+}
+
+// The history has no foreign key on purpose: "what were they on when they left"
+// is asked after the org is gone, usually in a refund dispute.
+func TestHistorySurvivesTheOrgBeingDeleted(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	ctx := t.Context()
+	if _, err := f.svc.SetPlan(ctx, f.orgID, actor, corebilling.Change{PlanSlug: "scale"}); err != nil {
+		t.Fatalf("SetPlan: %v", err)
+	}
+	if _, err := f.pg.PgW.Exec(ctx, "delete from orgs where id = $1", f.orgID); err != nil {
+		t.Fatalf("delete org: %v", err)
+	}
+
+	// The entitlement cascaded away with the org...
+	var live int
+	if err := f.pg.PgRO.QueryRow(ctx,
+		"select count(*) from billing_entitlements where org_id = $1", f.orgID).Scan(&live); err != nil {
+		t.Fatalf("count entitlements: %v", err)
+	}
+	if live != 0 {
+		t.Errorf("%d entitlement rows outlived the org, want 0", live)
+	}
+
+	// ...and the record of what they held did not.
+	entries, err := f.svc.History(ctx, f.orgID)
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Record.PlanSlug != "scale" {
+		t.Errorf("history after deletion = %+v, want the scale grant preserved", entries)
+	}
+}
+
+func TestSetPlanReportsAnUnknownOrg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	_, err := f.svc.SetPlan(t.Context(), xid.New().String(), actor, corebilling.Change{PlanSlug: "growth"})
+	if !errors.Is(err, corebilling.ErrOrgNotFound) {
+		t.Errorf("err = %v, want ErrOrgNotFound", err)
+	}
+}
+
+func TestSetPlanRefusesTheTrialSlug(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	f := newFixture(t)
+	_, err := f.svc.SetPlan(t.Context(), f.orgID, actor, corebilling.Change{PlanSlug: corebilling.SlugTrial})
+	if !errors.Is(err, corebilling.ErrTrialNotSettable) {
+		t.Errorf("err = %v, want ErrTrialNotSettable", err)
+	}
+}

--- a/internal/core/billing/main_test.go
+++ b/internal/core/billing/main_test.go
@@ -1,0 +1,9 @@
+package billing_test
+
+import (
+	"testing"
+
+	"github.com/pug-sh/pug/internal/testutil"
+)
+
+func TestMain(m *testing.M) { testutil.Main(m) }

--- a/internal/core/billing/retired_test.go
+++ b/internal/core/billing/retired_test.go
@@ -1,0 +1,108 @@
+package billing
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/pug-sh/pug/internal/gen/repo/dbwrite"
+	"github.com/pug-sh/pug/internal/testutil"
+	"github.com/rs/xid"
+)
+
+// No tier is retired yet, so the guard has nothing in the real catalog to act on
+// — and an unexercised guard is one that stops working without anyone noticing.
+// This test appends a retired tier for its duration, which is why it lives inside
+// the package rather than in billing_test.
+//
+// What it protects: repricing mints a new slug and retires the old one (see the
+// immutability rule in plans.go). If the retired slug could still be granted,
+// every reprice would go on handing out the superseded numbers.
+func TestRetiredPlanCannotBeGrantedToANewOrg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	original := catalog
+	t.Cleanup(func() { catalog = original })
+	catalog = append(append([]Plan(nil), original...), Plan{
+		Slug: "growth-v0", DisplayName: "Growth (2025)", Currency: "USD",
+		PriceCents: i64(1_500), IncludedEvents: i64(400_000), Retired: true,
+	})
+
+	pg := testutil.SetupPostgres(t)
+	ctx := t.Context()
+	svc, err := NewService(pg.PgRO, pg.PgW, true)
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+
+	newOrg := seedOrg(t, pg)
+	if _, err := svc.SetPlan(ctx, newOrg, "tester", Change{PlanSlug: "growth-v0"}); !errors.Is(err, ErrPlanRetired) {
+		t.Fatalf("granting a retired tier to a new org: err = %v, want ErrPlanRetired", err)
+	}
+
+	// A live tier is unaffected, so the guard is refusing retirement rather than
+	// everything.
+	if _, err := svc.SetPlan(ctx, newOrg, "tester", Change{PlanSlug: "growth"}); err != nil {
+		t.Errorf("granting a live tier: %v", err)
+	}
+
+}
+
+// The other half of the rule, and the entire point of retiring rather than
+// deleting a tier: an org already on one keeps it and can still be renewed.
+// Retiring an EXISTING slug needs no migration — the check constraint already
+// knows it — so this seeds on the real `growth` and then retires it.
+func TestRetiredPlanIsStillRenewableByItsHolder(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	pg := testutil.SetupPostgres(t)
+	ctx := t.Context()
+	svc, err := NewService(pg.PgRO, pg.PgW, true)
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+
+	incumbent := seedOrg(t, pg)
+	if _, err := svc.SetPlan(ctx, incumbent, "tester", Change{PlanSlug: "growth"}); err != nil {
+		t.Fatalf("seed the incumbent on a live tier: %v", err)
+	}
+
+	original := catalog
+	t.Cleanup(func() { catalog = original })
+	retired := append([]Plan(nil), original...)
+	for i := range retired {
+		if retired[i].Slug == "growth" {
+			retired[i].Retired = true
+		}
+	}
+	catalog = retired
+
+	// A renewal is a re-set with a new end date on unchanged terms.
+	if _, err := svc.SetPlan(ctx, incumbent, "tester", Change{
+		PlanSlug:       "growth",
+		ContractEndsAt: new(time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)),
+	}); err != nil {
+		t.Errorf("renewing a holder of a now-retired tier: %v", err)
+	}
+
+	newcomer := seedOrg(t, pg)
+	if _, err := svc.SetPlan(ctx, newcomer, "tester", Change{PlanSlug: "growth"}); !errors.Is(err, ErrPlanRetired) {
+		t.Errorf("granting the same tier to a newcomer: err = %v, want ErrPlanRetired", err)
+	}
+}
+
+func seedOrg(t *testing.T, pg *testutil.TestPostgres) string {
+	t.Helper()
+	org, err := dbwrite.New(pg.PgW).CreateOrg(t.Context(), dbwrite.CreateOrgParams{
+		ID:          xid.New().String(),
+		DisplayName: "acme-" + xid.New().String(),
+	})
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	return org.ID
+}

--- a/internal/core/billing/service.go
+++ b/internal/core/billing/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"time"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -135,7 +136,8 @@ func recordFromRow(row dbread.GetOrgEntitlementRow) Record {
 	return rec
 }
 
-// MaxDisplayNameLen mirrors display_name_override's varchar(150).
+// MaxDisplayNameLen mirrors display_name_override's varchar(150), which bounds
+// characters rather than bytes.
 const MaxDisplayNameLen = 150
 
 // Change is one operator edit. PlanSlug is required; every other field is nil to
@@ -193,7 +195,7 @@ func (s *Service) SetPlan(ctx context.Context, orgID, actor string, change Chang
 			return Record{}, ErrAnchorDayRange
 		}
 		// Mirrors the column's varchar(150), for the same reason as the checks above.
-		if len(next.DisplayNameOverride) > MaxDisplayNameLen {
+		if utf8.RuneCountInString(next.DisplayNameOverride) > MaxDisplayNameLen {
 			return Record{}, ErrDisplayNameLong
 		}
 		return next, nil

--- a/internal/core/billing/service.go
+++ b/internal/core/billing/service.go
@@ -29,6 +29,7 @@ var (
 	ErrCustomNeedsQuota = errors.New("billing: the custom plan requires an events override")
 	ErrAnchorDayRange   = errors.New("billing: anchor day must be between 1 and 31")
 	ErrQuotaNegative    = errors.New("billing: the events override must be positive")
+	ErrDisplayNameLong  = errors.New("billing: the display name override is too long")
 	// ErrTrialNotExtended guards a date that would move the org's trial end
 	// backwards, which "extend" must never do.
 	ErrTrialNotExtended = errors.New("billing: that trial end is not later than the current one")
@@ -36,6 +37,9 @@ var (
 	// ErrTrialOnGrantedPlan guards a trial date that would resolve to nothing: a
 	// granted plan wins over it, so the write would look like it worked.
 	ErrTrialOnGrantedPlan = errors.New("billing: clear the granted plan before extending a trial")
+	// ErrTrialOnLapsedContract guards the same empty write reached the other way:
+	// a lapsed contract expires the trial branch too.
+	ErrTrialOnLapsedContract = errors.New("billing: clear the lapsed contract before extending a trial")
 	// ErrNoEntitlement is a clear that found nothing stored. The org is already on
 	// the derived floors, but nothing was deleted.
 	ErrNoEntitlement = errors.New("billing: no entitlement stored for this org")
@@ -45,17 +49,17 @@ var (
 // `pug billing`. No RPC mutates an entitlement, so nothing here is behind a
 // second type.
 type Service struct {
-	read  *dbread.Queries
-	write *dbwrite.Queries
-	pgW   *pgxpool.Pool // every mutation runs in a tx of its own, alongside its history append
+	read *dbread.Queries
+	pgW  *pgxpool.Pool // every mutation runs in a tx of its own, alongside its history append
 	// billingEnabled mirrors PUG_BILLING_ENABLED. Off means a self-hosted install,
 	// where every org resolves with no quota at all, so no client can render a
 	// limit that does not apply.
 	billingEnabled bool
 }
 
-// NewService checks the floors at wiring time: a catalog missing one resolves
-// every org to a blank plan with no quota, and looks healthy doing it.
+// NewService checks the floors at wiring time, where mustPlan would otherwise
+// panic inside Resolve on a request — a startup failure names the problem, a
+// recovered panic per dashboard load does not.
 func NewService(pgRO *pgxpool.Pool, pgW *pgxpool.Pool, billingEnabled bool) (*Service, error) {
 	for _, slug := range []string{SlugFree, SlugTrial} {
 		if _, ok := PlanBySlug(slug); !ok {
@@ -64,7 +68,6 @@ func NewService(pgRO *pgxpool.Pool, pgW *pgxpool.Pool, billingEnabled bool) (*Se
 	}
 	return &Service{
 		read:           dbread.New(pgRO),
-		write:          dbwrite.New(pgW),
 		pgW:            pgW,
 		billingEnabled: billingEnabled,
 	}, nil
@@ -132,6 +135,9 @@ func recordFromRow(row dbread.GetOrgEntitlementRow) Record {
 	return rec
 }
 
+// MaxDisplayNameLen mirrors display_name_override's varchar(150).
+const MaxDisplayNameLen = 150
+
 // Change is one operator edit. PlanSlug is required; every other field is nil to
 // leave the stored value alone, or a value to write — the zero value being the
 // clear.
@@ -168,7 +174,7 @@ func (s *Service) SetPlan(ctx context.Context, orgID, actor string, change Chang
 		return Record{}, ErrTrialNotSettable
 	}
 
-	return s.mutate(ctx, orgID, actor, func(cur Record) (Record, error) {
+	return s.mutate(ctx, orgID, actor, func(_ *dbwrite.Queries, cur Record) (Record, error) {
 		next := applyChange(cur, change)
 		// A retired tier keeps its existing holders but is never handed to somebody
 		// new, so this is checked against what the org held BEFORE the change.
@@ -186,6 +192,10 @@ func (s *Service) SetPlan(ctx context.Context, orgID, actor string, change Chang
 		if next.AnchorDay < 0 || next.AnchorDay > 31 {
 			return Record{}, ErrAnchorDayRange
 		}
+		// Mirrors the column's varchar(150), for the same reason as the checks above.
+		if len(next.DisplayNameOverride) > MaxDisplayNameLen {
+			return Record{}, ErrDisplayNameLong
+		}
 		return next, nil
 	})
 }
@@ -197,13 +207,15 @@ func (s *Service) ExtendTrial(ctx context.Context, orgID, actor string, days int
 	if days <= 0 || days > MaxTrialDays {
 		return Record{}, ErrTrialDaysRange
 	}
-	// The org's create time, because the trial being extended is usually the
-	// derived one and the locked row alone cannot see it.
-	orgCreateTime, err := s.orgCreateTime(ctx, orgID)
-	if err != nil {
-		return Record{}, err
-	}
-	return s.mutate(ctx, orgID, actor, func(cur Record) (Record, error) {
+	return s.mutate(ctx, orgID, actor, func(w *dbwrite.Queries, cur Record) (Record, error) {
+		// The org's create time, because the trial being extended is usually the
+		// derived one and the locked row alone cannot see it. Read through the tx,
+		// not s.read: against a real replica a lagging read would report
+		// ErrOrgNotFound for an org that was just created.
+		orgCreateTime, err := orgCreateTime(ctx, w, orgID)
+		if err != nil {
+			return Record{}, err
+		}
 		// A granted plan resolves ahead of any trial date, so writing one here would
 		// store a date that changes nothing and still print as a success. A slug the
 		// catalog no longer knows counts as granted: it resolves free without ever
@@ -211,6 +223,11 @@ func (s *Service) ExtendTrial(ctx context.Context, orgID, actor string, days int
 		if cur.Present {
 			if plan, ok := PlanBySlug(cur.PlanSlug); !ok || !plan.isFloor() {
 				return Record{}, ErrTrialOnGrantedPlan
+			}
+			// A lapsed contract expires the trial branch too, so the date would be just
+			// as empty — a comped pilot that has ended needs a fresh grant, not a trial.
+			if contractLapsed(cur, now) {
+				return Record{}, ErrTrialOnLapsedContract
 			}
 		}
 		next := cur
@@ -279,7 +296,7 @@ func (s *Service) Clear(ctx context.Context, orgID, actor string) error {
 // mutate runs one read-modify-write under a row lock, appending the resulting
 // snapshot to the history in the same transaction — so a change and its record
 // commit together or not at all.
-func (s *Service) mutate(ctx context.Context, orgID, actor string, edit func(Record) (Record, error)) (Record, error) {
+func (s *Service) mutate(ctx context.Context, orgID, actor string, edit func(*dbwrite.Queries, Record) (Record, error)) (Record, error) {
 	tx, err := s.begin(ctx)
 	if err != nil {
 		return Record{}, err
@@ -301,7 +318,7 @@ func (s *Service) mutate(ctx context.Context, orgID, actor string, edit func(Rec
 		return Record{}, err
 	}
 
-	next, err := edit(cur)
+	next, err := edit(w, cur)
 	if err != nil {
 		return Record{}, err
 	}
@@ -347,8 +364,8 @@ func (s *Service) commit(ctx context.Context, tx pgx.Tx, orgID string) error {
 
 // orgCreateTime reads the org's age, which is what the derived trial is measured
 // from.
-func (s *Service) orgCreateTime(ctx context.Context, orgID string) (time.Time, error) {
-	row, err := s.read.GetOrgEntitlement(ctx, orgID)
+func orgCreateTime(ctx context.Context, w *dbwrite.Queries, orgID string) (time.Time, error) {
+	org, err := w.GetOrgByID(ctx, orgID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return time.Time{}, ErrOrgNotFound
@@ -357,7 +374,7 @@ func (s *Service) orgCreateTime(ctx context.Context, orgID string) (time.Time, e
 		telemetry.RecordError(ctx, err)
 		return time.Time{}, err
 	}
-	return row.OrgCreateTime.Time, nil
+	return org.CreateTime.Time, nil
 }
 
 func currentRecord(ctx context.Context, w *dbwrite.Queries, orgID string) (Record, error) {
@@ -409,9 +426,12 @@ func applyChange(cur Record, c Change) Record {
 			next.TrialEndsAt = time.Time{}
 		} else if c.ContractEndsAt == nil {
 			// The mirror: the contract belongs to the granted plan, so falling back to a
-			// floor tier ends it. Unless this change names one, which is a time-boxed
-			// comped grant on the floor.
+			// floor tier ends it — and the overrides it gated with it, or clearing the
+			// date would turn a time-boxed quota into a permanent one. Unless this
+			// change names them, which is a comped grant on the floor.
 			next.ContractEndsAt = time.Time{}
+			next.IncludedEventsOverride = orKeep(c.IncludedEvents, 0)
+			next.DisplayNameOverride = orKeep(c.DisplayName, "")
 		}
 	}
 	return next

--- a/internal/core/billing/service.go
+++ b/internal/core/billing/service.go
@@ -1,0 +1,502 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pug-sh/pug/internal/deps/postgres"
+	"github.com/pug-sh/pug/internal/deps/telemetry"
+	"github.com/pug-sh/pug/internal/gen/repo/dbread"
+	"github.com/pug-sh/pug/internal/gen/repo/dbwrite"
+	"github.com/pug-sh/pug/internal/slogx"
+	"github.com/rs/xid"
+)
+
+var (
+	ErrOrgNotFound = errors.New("billing: org not found")
+	// ErrPlanNotFound is a slug the catalog does not have. Distinct from
+	// ErrPlanRetired, which is a slug it has but will not hand to a new org.
+	ErrPlanNotFound = errors.New("billing: plan not found")
+	ErrPlanRetired  = errors.New("billing: plan is retired and cannot be newly assigned")
+	// ErrTrialNotSettable guards the one slug that means nothing without a date.
+	ErrTrialNotSettable = errors.New("billing: use extend-trial to put an org on the trial plan")
+	ErrCustomNeedsQuota = errors.New("billing: the custom plan requires an events override")
+	ErrAnchorDayRange   = errors.New("billing: anchor day must be between 1 and 31")
+	ErrQuotaNegative    = errors.New("billing: the events override must be positive")
+	// ErrTrialNotExtended guards a date that would move the org's trial end
+	// backwards, which "extend" must never do.
+	ErrTrialNotExtended = errors.New("billing: that trial end is not later than the current one")
+	ErrTrialDaysRange   = errors.New("billing: trial extension must be between 1 and 365 days")
+	// ErrTrialOnGrantedPlan guards a trial date that would resolve to nothing: a
+	// granted plan wins over it, so the write would look like it worked.
+	ErrTrialOnGrantedPlan = errors.New("billing: clear the granted plan before extending a trial")
+	// ErrNoEntitlement is a clear that found nothing stored. The org is already on
+	// the derived floors, but nothing was deleted.
+	ErrNoEntitlement = errors.New("billing: no entitlement stored for this org")
+)
+
+// Service is the whole package: GetEntitlement for the dashboard, the rest for
+// `pug billing`. No RPC mutates an entitlement, so nothing here is behind a
+// second type.
+type Service struct {
+	read  *dbread.Queries
+	write *dbwrite.Queries
+	pgW   *pgxpool.Pool // every mutation runs in a tx of its own, alongside its history append
+	// billingEnabled mirrors PUG_BILLING_ENABLED. Off means a self-hosted install,
+	// where every org resolves with no quota at all, so no client can render a
+	// limit that does not apply.
+	billingEnabled bool
+}
+
+// NewService checks the floors at wiring time: a catalog missing one resolves
+// every org to a blank plan with no quota, and looks healthy doing it.
+func NewService(pgRO *pgxpool.Pool, pgW *pgxpool.Pool, billingEnabled bool) (*Service, error) {
+	for _, slug := range []string{SlugFree, SlugTrial} {
+		if _, ok := PlanBySlug(slug); !ok {
+			return nil, fmt.Errorf("billing: catalog is missing the floor plan %q", slug)
+		}
+	}
+	return &Service{
+		read:           dbread.New(pgRO),
+		write:          dbwrite.New(pgW),
+		pgW:            pgW,
+		billingEnabled: billingEnabled,
+	}, nil
+}
+
+// GetEntitlement resolves what the org may send right now.
+func (s *Service) GetEntitlement(ctx context.Context, orgID string, now time.Time) (Entitlement, error) {
+	row, err := s.read.GetOrgEntitlement(ctx, orgID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Entitlement{}, ErrOrgNotFound
+		}
+		slog.ErrorContext(ctx, "failed to read the org entitlement", slogx.Error(err), slog.String("org_id", orgID))
+		telemetry.RecordError(ctx, err)
+		return Entitlement{}, err
+	}
+	rec := recordFromRow(row)
+	// Detected here rather than in Resolve, which is pure and has no ctx to log
+	// against. Only reachable if a slug left the catalog with rows still on it,
+	// which only an operator can clear — so this is a warning, not an error a
+	// dashboard load should record as an exception on every request.
+	if rec.Present {
+		if _, known := PlanBySlug(rec.PlanSlug); !known {
+			slog.WarnContext(ctx, "entitlement names a plan the catalog does not know",
+				slog.String("org_id", orgID), slog.String("plan_slug", rec.PlanSlug))
+		}
+	}
+	return Resolve(row.OrgCreateTime.Time, rec, now, s.billingEnabled), nil
+}
+
+// StoredRecord is the row as stored. `pug billing show` prints it beside the
+// resolved entitlement, because an override that is not in force today — a
+// lapsed deal's quota, say — is invisible in the resolved answer alone.
+func (s *Service) StoredRecord(ctx context.Context, orgID string) (Record, error) {
+	row, err := s.read.GetOrgEntitlement(ctx, orgID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Record{}, ErrOrgNotFound
+		}
+		slog.ErrorContext(ctx, "failed to read the stored entitlement", slogx.Error(err), slog.String("org_id", orgID))
+		telemetry.RecordError(ctx, err)
+		return Record{}, err
+	}
+	return recordFromRow(row), nil
+}
+
+// recordFromRow maps the left-joined read. A NULL plan_slug is the join finding
+// no entitlement, which is the ordinary case and not an error.
+func recordFromRow(row dbread.GetOrgEntitlementRow) Record {
+	if !row.PlanSlug.Valid {
+		return Record{}
+	}
+	rec := Record{
+		Present:             true,
+		AnchorDay:           postgres.Int2ToInt(row.AnchorDay),
+		ContractEndsAt:      row.ContractEndsAt.Time,
+		DisplayNameOverride: row.DisplayNameOverride.String,
+		Note:                row.Note.String,
+		PlanSlug:            row.PlanSlug.String,
+		TrialEndsAt:         row.TrialEndsAt.Time,
+	}
+	if row.IncludedEventsOverride.Valid {
+		rec.IncludedEventsOverride = row.IncludedEventsOverride.Int64
+	}
+	return rec
+}
+
+// Change is one operator edit. PlanSlug is required; every other field is nil to
+// leave the stored value alone, or a value to write — the zero value being the
+// clear.
+//
+// Leaving values alone is the default because the common re-set is a renewal — a
+// new end date on terms that have not changed — and a flag that silently
+// reverted a customer's negotiated quota to a catalog number would be the most
+// expensive bug this API could have.
+type Change struct {
+	PlanSlug       string
+	IncludedEvents *int64
+	DisplayName    *string
+	AnchorDay      *int
+	ContractEndsAt *time.Time
+	Note           *string
+}
+
+// orKeep resolves one Change field against the value already stored.
+func orKeep[T any](v *T, current T) T {
+	if v == nil {
+		return current
+	}
+	return *v
+}
+
+// SetPlan grants a plan, merging the change over whatever is stored. Returns the
+// row as it now stands.
+func (s *Service) SetPlan(ctx context.Context, orgID, actor string, change Change) (Record, error) {
+	plan, ok := PlanBySlug(change.PlanSlug)
+	if !ok {
+		return Record{}, ErrPlanNotFound
+	}
+	if plan.Slug == SlugTrial {
+		return Record{}, ErrTrialNotSettable
+	}
+
+	return s.mutate(ctx, orgID, actor, func(cur Record) (Record, error) {
+		next := applyChange(cur, change)
+		// A retired tier keeps its existing holders but is never handed to somebody
+		// new, so this is checked against what the org held BEFORE the change.
+		if plan.Retired && cur.PlanSlug != plan.Slug {
+			return Record{}, ErrPlanRetired
+		}
+		if next.PlanSlug == SlugCustom && next.IncludedEventsOverride <= 0 {
+			return Record{}, ErrCustomNeedsQuota
+		}
+		// Mirrors the column's `> 0` check, which would otherwise surface as a raw
+		// SQLSTATE logged as a pug fault.
+		if next.IncludedEventsOverride < 0 {
+			return Record{}, ErrQuotaNegative
+		}
+		if next.AnchorDay < 0 || next.AnchorDay > 31 {
+			return Record{}, ErrAnchorDayRange
+		}
+		return next, nil
+	})
+}
+
+// ExtendTrial moves the org's trial end to days from now, which is what puts a
+// trial_ends_at on the row at all — every other org's trial is derived from its
+// age and stores nothing.
+func (s *Service) ExtendTrial(ctx context.Context, orgID, actor string, days int, now time.Time) (Record, error) {
+	if days <= 0 || days > MaxTrialDays {
+		return Record{}, ErrTrialDaysRange
+	}
+	// The org's create time, because the trial being extended is usually the
+	// derived one and the locked row alone cannot see it.
+	orgCreateTime, err := s.orgCreateTime(ctx, orgID)
+	if err != nil {
+		return Record{}, err
+	}
+	return s.mutate(ctx, orgID, actor, func(cur Record) (Record, error) {
+		// A granted plan resolves ahead of any trial date, so writing one here would
+		// store a date that changes nothing and still print as a success. A slug the
+		// catalog no longer knows counts as granted: it resolves free without ever
+		// consulting a trial date, so the write would be just as empty.
+		if cur.Present {
+			if plan, ok := PlanBySlug(cur.PlanSlug); !ok || !plan.isFloor() {
+				return Record{}, ErrTrialOnGrantedPlan
+			}
+		}
+		next := cur
+		next.Present = true
+		next.TrialEndsAt = now.AddDate(0, 0, days).UTC().Truncate(time.Second)
+		// "Extend" is measured from now, so a small --days on a trial with longer to
+		// run would shorten it. Refuse rather than silently cut it short.
+		if !next.TrialEndsAt.After(trialEnd(orgCreateTime, cur)) {
+			return Record{}, ErrTrialNotExtended
+		}
+		// An org with no row has no plan either, and plan_slug is NOT NULL. The
+		// floor is the honest value: extending a trial grants no tier.
+		if next.PlanSlug == "" {
+			next.PlanSlug = SlugFree
+		}
+		return next, nil
+	})
+}
+
+// Clear deletes the row, returning the org to the derived floors. Recorded in
+// the history as a snapshot with no values.
+func (s *Service) Clear(ctx context.Context, orgID, actor string) error {
+	tx, err := s.begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	w := dbwrite.New(tx)
+	// The same lock mutate takes, for the same reason: without it a concurrent
+	// SetPlan can insert a row between this delete and its commit, leaving a stored
+	// entitlement whose newest history entry says it was cleared.
+	if err := w.LockBillingEntitlementOrg(ctx, orgID); err != nil {
+		slog.ErrorContext(ctx, "failed to lock the org for a billing clear", slogx.Error(err),
+			slog.String("org_id", orgID))
+		telemetry.RecordError(ctx, err)
+		return err
+	}
+	n, err := w.DeleteBillingEntitlement(ctx, orgID)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to delete the entitlement", slogx.Error(err), slog.String("org_id", orgID))
+		telemetry.RecordError(ctx, err)
+		return err
+	}
+	// Deleting nothing is not success: it is either a typo'd org or a row that was
+	// never there, and both would otherwise print as "cleared".
+	if n == 0 {
+		// Through the tx, not s.read: against a real replica, a lagging read would
+		// report ErrOrgNotFound for an org that was just created.
+		if _, err := w.GetOrgByID(ctx, orgID); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrOrgNotFound
+			}
+			slog.ErrorContext(ctx, "failed to check the org exists", slogx.Error(err), slog.String("org_id", orgID))
+			telemetry.RecordError(ctx, err)
+			return err
+		}
+		return ErrNoEntitlement
+	}
+	if err := appendHistory(ctx, w, orgID, actor, Record{}); err != nil {
+		return err
+	}
+	return s.commit(ctx, tx, orgID)
+}
+
+// mutate runs one read-modify-write under a row lock, appending the resulting
+// snapshot to the history in the same transaction — so a change and its record
+// commit together or not at all.
+func (s *Service) mutate(ctx context.Context, orgID, actor string, edit func(Record) (Record, error)) (Record, error) {
+	tx, err := s.begin(ctx)
+	if err != nil {
+		return Record{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	w := dbwrite.New(tx)
+	// Before the read, because `for update` locks nothing when the row does not
+	// exist yet: without this two concurrent first writes both read an empty
+	// record and the second full-replaces the first.
+	if err := w.LockBillingEntitlementOrg(ctx, orgID); err != nil {
+		slog.ErrorContext(ctx, "failed to lock the org for a billing write", slogx.Error(err),
+			slog.String("org_id", orgID))
+		telemetry.RecordError(ctx, err)
+		return Record{}, err
+	}
+	cur, err := currentRecord(ctx, w, orgID)
+	if err != nil {
+		return Record{}, err
+	}
+
+	next, err := edit(cur)
+	if err != nil {
+		return Record{}, err
+	}
+
+	row, err := w.UpsertBillingEntitlement(ctx, upsertParams(orgID, next))
+	if err != nil {
+		if isOrgFKViolation(err) {
+			return Record{}, ErrOrgNotFound
+		}
+		slog.ErrorContext(ctx, "failed to upsert the entitlement", slogx.Error(err), slog.String("org_id", orgID))
+		telemetry.RecordError(ctx, err)
+		return Record{}, err
+	}
+
+	stored := recordFromWriteRow(row)
+	if err := appendHistory(ctx, w, orgID, actor, stored); err != nil {
+		return Record{}, err
+	}
+	if err := s.commit(ctx, tx, orgID); err != nil {
+		return Record{}, err
+	}
+	return stored, nil
+}
+
+func (s *Service) begin(ctx context.Context) (pgx.Tx, error) {
+	tx, err := s.pgW.Begin(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to begin the billing tx", slogx.Error(err))
+		telemetry.RecordError(ctx, err)
+		return nil, err
+	}
+	return tx, nil
+}
+
+func (s *Service) commit(ctx context.Context, tx pgx.Tx, orgID string) error {
+	if err := tx.Commit(ctx); err != nil {
+		slog.ErrorContext(ctx, "failed to commit the billing tx", slogx.Error(err), slog.String("org_id", orgID))
+		telemetry.RecordError(ctx, err)
+		return err
+	}
+	return nil
+}
+
+// orgCreateTime reads the org's age, which is what the derived trial is measured
+// from.
+func (s *Service) orgCreateTime(ctx context.Context, orgID string) (time.Time, error) {
+	row, err := s.read.GetOrgEntitlement(ctx, orgID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return time.Time{}, ErrOrgNotFound
+		}
+		slog.ErrorContext(ctx, "failed to read the org create time", slogx.Error(err), slog.String("org_id", orgID))
+		telemetry.RecordError(ctx, err)
+		return time.Time{}, err
+	}
+	return row.OrgCreateTime.Time, nil
+}
+
+func currentRecord(ctx context.Context, w *dbwrite.Queries, orgID string) (Record, error) {
+	row, err := w.GetBillingEntitlementForUpdate(ctx, orgID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Record{}, nil
+		}
+		slog.ErrorContext(ctx, "failed to lock the entitlement", slogx.Error(err), slog.String("org_id", orgID))
+		telemetry.RecordError(ctx, err)
+		return Record{}, err
+	}
+	return recordFromWriteRow(row), nil
+}
+
+// recordFromWriteRow maps the writer-side row, which GetBillingEntitlementForUpdate
+// and UpsertBillingEntitlement both return.
+func recordFromWriteRow(row dbwrite.BillingEntitlement) Record {
+	rec := Record{
+		Present:             true,
+		AnchorDay:           postgres.Int2ToInt(row.AnchorDay),
+		ContractEndsAt:      row.ContractEndsAt.Time,
+		DisplayNameOverride: row.DisplayNameOverride.String,
+		Note:                row.Note,
+		PlanSlug:            row.PlanSlug,
+		TrialEndsAt:         row.TrialEndsAt.Time,
+	}
+	if row.IncludedEventsOverride.Valid {
+		rec.IncludedEventsOverride = row.IncludedEventsOverride.Int64
+	}
+	return rec
+}
+
+func applyChange(cur Record, c Change) Record {
+	next := cur
+	next.Present = true
+	next.PlanSlug = c.PlanSlug
+	next.IncludedEventsOverride = orKeep(c.IncludedEvents, cur.IncludedEventsOverride)
+	next.DisplayNameOverride = orKeep(c.DisplayName, cur.DisplayNameOverride)
+	next.AnchorDay = orKeep(c.AnchorDay, cur.AnchorDay)
+	next.ContractEndsAt = orKeep(c.ContractEndsAt, cur.ContractEndsAt)
+	next.Note = orKeep(c.Note, cur.Note)
+
+	if plan, ok := PlanBySlug(next.PlanSlug); ok {
+		if !plan.isFloor() {
+			// Converting to a paid tier ends the trial: leaving a future trial_ends_at
+			// behind would make an entitlement whose state depends on which of two dates
+			// the resolver consults first.
+			next.TrialEndsAt = time.Time{}
+		} else if c.ContractEndsAt == nil {
+			// The mirror: the contract belongs to the granted plan, so falling back to a
+			// floor tier ends it. Unless this change names one, which is a time-boxed
+			// comped grant on the floor.
+			next.ContractEndsAt = time.Time{}
+		}
+	}
+	return next
+}
+
+func upsertParams(orgID string, rec Record) dbwrite.UpsertBillingEntitlementParams {
+	return dbwrite.UpsertBillingEntitlementParams{
+		AnchorDay:              postgres.NewOptionalInt2(rec.AnchorDay),
+		ContractEndsAt:         postgres.NewOptionalTimestamptz(rec.ContractEndsAt),
+		DisplayNameOverride:    postgres.NewOptionalText(rec.DisplayNameOverride),
+		IncludedEventsOverride: postgres.NewOptionalInt8(rec.IncludedEventsOverride),
+		Note:                   rec.Note,
+		OrgID:                  orgID,
+		PlanSlug:               rec.PlanSlug,
+		TrialEndsAt:            postgres.NewOptionalTimestamptz(rec.TrialEndsAt),
+	}
+}
+
+func appendHistory(ctx context.Context, w *dbwrite.Queries, orgID, actor string, rec Record) error {
+	params := dbwrite.InsertBillingEntitlementHistoryParams{
+		Actor:                  actor,
+		AnchorDay:              postgres.NewOptionalInt2(rec.AnchorDay),
+		ContractEndsAt:         postgres.NewOptionalTimestamptz(rec.ContractEndsAt),
+		DisplayNameOverride:    postgres.NewOptionalText(rec.DisplayNameOverride),
+		ID:                     xid.New().String(),
+		IncludedEventsOverride: postgres.NewOptionalInt8(rec.IncludedEventsOverride),
+		Note:                   rec.Note,
+		OrgID:                  orgID,
+		PlanSlug:               postgres.NewOptionalText(rec.PlanSlug),
+		TrialEndsAt:            postgres.NewOptionalTimestamptz(rec.TrialEndsAt),
+	}
+	if err := w.InsertBillingEntitlementHistory(ctx, params); err != nil {
+		slog.ErrorContext(ctx, "failed to append the entitlement history", slogx.Error(err),
+			slog.String("org_id", orgID))
+		telemetry.RecordError(ctx, err)
+		return err
+	}
+	return nil
+}
+
+// HistoryEntry is one recorded change, newest first from History.
+type HistoryEntry struct {
+	Actor     string
+	ChangedAt time.Time
+	Record    Record
+}
+
+// MaxHistoryRows caps one History read. An entitlement changes a handful of
+// times a year, so this is decades of it.
+const MaxHistoryRows = 200
+
+// History is operator and support data — no RPC serves it.
+func (s *Service) History(ctx context.Context, orgID string) ([]HistoryEntry, error) {
+	rows, err := s.read.ListBillingEntitlementHistory(ctx, dbread.ListBillingEntitlementHistoryParams{
+		OrgID:    orgID,
+		RowLimit: MaxHistoryRows,
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to read the entitlement history", slogx.Error(err),
+			slog.String("org_id", orgID))
+		telemetry.RecordError(ctx, err)
+		return nil, err
+	}
+	out := make([]HistoryEntry, 0, len(rows))
+	for _, row := range rows {
+		rec := Record{
+			Present:             row.PlanSlug.Valid,
+			AnchorDay:           postgres.Int2ToInt(row.AnchorDay),
+			ContractEndsAt:      row.ContractEndsAt.Time,
+			DisplayNameOverride: row.DisplayNameOverride.String,
+			Note:                row.Note,
+			PlanSlug:            row.PlanSlug.String,
+			TrialEndsAt:         row.TrialEndsAt.Time,
+		}
+		if row.IncludedEventsOverride.Valid {
+			rec.IncludedEventsOverride = row.IncludedEventsOverride.Int64
+		}
+		out = append(out, HistoryEntry{Actor: row.Actor, ChangedAt: row.ChangedAt.Time, Record: rec})
+	}
+	return out, nil
+}
+
+// isOrgFKViolation reports the upsert failing because no such org exists, which
+// is a caller mistake rather than a database fault.
+func isOrgFKViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23503"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added billing entitlement management for organization plans, quotas, trials, contract dates, and custom plan settings.
  - Added support for extending trials, clearing entitlements, viewing stored billing details, and reviewing entitlement history.
  - Organizations without an entitlement resolve to the free tier based on their age.
  - Self-hosted installations can disable billing limits entirely.
  - Retired plans can no longer be assigned to new organizations, while existing holders can renew them.
- **Bug Fixes**
  - Improved validation for plan changes, quotas, trial dates, anchor days, and display names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->