### PR TITLE
fix(dotenv): fail loudly on a broken .env

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -112,6 +112,12 @@ linters:
           deny:
             - pkg: github.com/pug-sh/pug/internal/testutil
               desc: the testcontainers harness must not link into a production binary
+        # One loader: only dotenv.Load tells an absent .env from a broken one.
+        dotenv-single-loader:
+          files: ["!**/internal/dotenv/**"]
+          deny:
+            - pkg: github.com/joho/godotenv
+              desc: load .env through dotenv.LoadOrExit, which exits on anything but an absent file
     sloglint:
       # no-global is deliberately unset: it wants a logger passed around, but
       # pug calls slog.XxxContext directly everywhere. context is the rule we want.

--- a/cmd/cron/billing-reconcile/main.go
+++ b/cmd/cron/billing-reconcile/main.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/joho/godotenv"
 	billingcron "github.com/pug-sh/pug/internal/app/cron/billing"
+	"github.com/pug-sh/pug/internal/dotenv"
 	"github.com/pug-sh/pug/internal/slogx"
 )
 
@@ -16,9 +16,7 @@ func main() {
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	if err := godotenv.Load(); err != nil {
-		slog.DebugContext(ctx, "No .env file found, relying on environment variables")
-	}
+	dotenv.LoadOrExit(ctx)
 
 	// Run has already logged the failure through the OTLP handler; this line goes
 	// to stderr after telemetry shut down, so it says only what main adds.

--- a/cmd/cron/usage/main.go
+++ b/cmd/cron/usage/main.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/joho/godotenv"
 	usagecron "github.com/pug-sh/pug/internal/app/cron/usage"
+	"github.com/pug-sh/pug/internal/dotenv"
 	"github.com/pug-sh/pug/internal/slogx"
 )
 
@@ -16,9 +16,7 @@ func main() {
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	if err := godotenv.Load(); err != nil {
-		slog.DebugContext(ctx, "No .env file found, relying on environment variables")
-	}
+	dotenv.LoadOrExit(ctx)
 
 	// Run has already logged the failure through the OTLP handler; this line goes
 	// to stderr after telemetry shut down, so it says only what main adds.

--- a/cmd/migrate/clickhouse/main.go
+++ b/cmd/migrate/clickhouse/main.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/joho/godotenv"
 	"github.com/pug-sh/pug/internal/app/migrate/clickhouse"
+	"github.com/pug-sh/pug/internal/dotenv"
 	"github.com/pug-sh/pug/internal/slogx"
 )
 
@@ -16,9 +16,7 @@ func main() {
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	if err := godotenv.Load(); err != nil {
-		slog.DebugContext(ctx, "No .env file found, relying on environment variables")
-	}
+	dotenv.LoadOrExit(ctx)
 
 	if err := clickhouse.Up(ctx, 0); err != nil {
 		slog.ErrorContext(ctx, "clickhouse migration error", slogx.Error(err))

--- a/cmd/migrate/nats/main.go
+++ b/cmd/migrate/nats/main.go
@@ -5,17 +5,15 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/joho/godotenv"
 	"github.com/pug-sh/pug/internal/app/migrate/nats"
+	"github.com/pug-sh/pug/internal/dotenv"
 	"github.com/pug-sh/pug/internal/slogx"
 )
 
 func main() {
 	ctx := context.Background()
 
-	if err := godotenv.Load(); err != nil {
-		slog.DebugContext(ctx, "No .env file found")
-	}
+	dotenv.LoadOrExit(ctx)
 
 	if err := nats.Run(ctx); err != nil {
 		slog.ErrorContext(ctx, "NATS initialization error", slogx.Error(err))

--- a/cmd/migrate/postgres/main.go
+++ b/cmd/migrate/postgres/main.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/joho/godotenv"
 	"github.com/pug-sh/pug/internal/app/migrate/postgres"
+	"github.com/pug-sh/pug/internal/dotenv"
 	"github.com/pug-sh/pug/internal/slogx"
 )
 
@@ -16,9 +16,7 @@ func main() {
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	if err := godotenv.Load(); err != nil {
-		slog.DebugContext(ctx, "No .env file found, relying on environment variables")
-	}
+	dotenv.LoadOrExit(ctx)
 
 	if err := postgres.Up(ctx, 0); err != nil {
 		slog.ErrorContext(ctx, "postgres migration error", slogx.Error(err))

--- a/cmd/pug/billing.go
+++ b/cmd/pug/billing.go
@@ -11,9 +11,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/joho/godotenv"
 	appbilling "github.com/pug-sh/pug/internal/app/billing"
 	corebilling "github.com/pug-sh/pug/internal/core/billing"
+	"github.com/pug-sh/pug/internal/dotenv"
 	"github.com/spf13/cobra"
 )
 
@@ -216,10 +216,8 @@ func billingRunE(fn func(context.Context, *appbilling.CLI, *cobra.Command, strin
 		ctx, done := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 		defer done()
 
-		if err := godotenv.Load(); err != nil {
-			slog.DebugContext(ctx, "No .env file found, relying on environment variables")
-		}
 		slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
+		dotenv.LoadOrExit(ctx)
 
 		cli, err := appbilling.New(ctx)
 		if err != nil {

--- a/cmd/pug/main.go
+++ b/cmd/pug/main.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/joho/godotenv"
 	usagecron "github.com/pug-sh/pug/internal/app/cron/usage"
 	"github.com/pug-sh/pug/internal/app/migrate/clickhouse"
 	migratenats "github.com/pug-sh/pug/internal/app/migrate/nats"
@@ -27,6 +26,7 @@ import (
 	coreemail "github.com/pug-sh/pug/internal/core/email"
 	"github.com/pug-sh/pug/internal/core/email/templates"
 	natsworker "github.com/pug-sh/pug/internal/deps/nats"
+	"github.com/pug-sh/pug/internal/dotenv"
 	"github.com/pug-sh/pug/internal/slogx"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -47,9 +47,7 @@ func run(fn func(ctx context.Context) error) func(cmd *cobra.Command, args []str
 		ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 		defer done()
 
-		if err := godotenv.Load(); err != nil {
-			slog.DebugContext(ctx, "No .env file found, relying on environment variables")
-		}
+		dotenv.LoadOrExit(ctx)
 
 		if err := fn(ctx); err != nil {
 			slog.ErrorContext(ctx, "fatal error", slogx.Error(err))
@@ -65,9 +63,7 @@ func runMigrate(up, down func(ctx context.Context, num int) error) func(cmd *cob
 		ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 		defer done()
 
-		if err := godotenv.Load(); err != nil {
-			slog.DebugContext(ctx, "No .env file found, relying on environment variables")
-		}
+		dotenv.LoadOrExit(ctx)
 
 		direction, _ := cmd.Flags().GetString("direction")
 		num, _ := cmd.Flags().GetInt("num")
@@ -207,6 +203,8 @@ var emailPreviewCmd = &cobra.Command{
 	Short: "Render a transactional email to HTML (or --text) for preview",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		dotenv.LoadOrExit(cmd.Context())
+
 		dashboardURL := os.Getenv("PUG_DASHBOARD_BASE_URL")
 		if dashboardURL == "" {
 			dashboardURL = "https://app.pug.sh"
@@ -260,9 +258,7 @@ var devCmd = &cobra.Command{
 		sigCtx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 		defer done()
 
-		if err := godotenv.Load(); err != nil {
-			slog.DebugContext(sigCtx, "No .env file found, relying on environment variables")
-		}
+		dotenv.LoadOrExit(sigCtx)
 
 		// `pug dev` runs every worker in one local process; the health/readiness
 		// endpoints are for orchestrated deployments, so force them off here to
@@ -367,9 +363,7 @@ var seedCmd = &cobra.Command{
 		ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 		defer done()
 
-		if err := godotenv.Load(); err != nil {
-			slog.DebugContext(ctx, "No .env file found, relying on environment variables")
-		}
+		dotenv.LoadOrExit(ctx)
 
 		count, _ := cmd.Flags().GetInt64("count")
 		batchSize, _ := cmd.Flags().GetInt("batch")

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/joho/godotenv"
 	"github.com/pug-sh/pug/internal/app/server"
+	"github.com/pug-sh/pug/internal/dotenv"
 	"github.com/pug-sh/pug/internal/slogx"
 )
 
@@ -16,9 +16,7 @@ func main() {
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	if err := godotenv.Load(); err != nil {
-		slog.DebugContext(ctx, "No .env file found, relying on environment variables")
-	}
+	dotenv.LoadOrExit(ctx)
 
 	if err := server.Run(ctx); err != nil {
 		slog.ErrorContext(ctx, "server error", slogx.Error(err))

--- a/cmd/workers/compliance/main.go
+++ b/cmd/workers/compliance/main.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/joho/godotenv"
 	"github.com/pug-sh/pug/internal/app/workers/compliance"
+	"github.com/pug-sh/pug/internal/dotenv"
 	"github.com/pug-sh/pug/internal/slogx"
 )
 
@@ -16,9 +16,7 @@ func main() {
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	if err := godotenv.Load(); err != nil {
-		slog.DebugContext(ctx, "No .env file found, relying on environment variables")
-	}
+	dotenv.LoadOrExit(ctx)
 
 	if err := compliance.Run(ctx); err != nil {
 		slog.ErrorContext(ctx, "error starting compliance worker", slogx.Error(err))

--- a/cmd/workers/demo/main.go
+++ b/cmd/workers/demo/main.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/joho/godotenv"
 	"github.com/pug-sh/pug/internal/app/workers/demo"
+	"github.com/pug-sh/pug/internal/dotenv"
 	"github.com/pug-sh/pug/internal/slogx"
 )
 
@@ -16,9 +16,7 @@ func main() {
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	if err := godotenv.Load(); err != nil {
-		slog.DebugContext(ctx, "No .env file found, relying on environment variables")
-	}
+	dotenv.LoadOrExit(ctx)
 
 	if err := demo.Run(ctx); err != nil {
 		slog.ErrorContext(ctx, "error starting demo worker", slogx.Error(err))

--- a/cmd/workers/email/main.go
+++ b/cmd/workers/email/main.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/joho/godotenv"
 	emailworker "github.com/pug-sh/pug/internal/app/workers/email"
+	"github.com/pug-sh/pug/internal/dotenv"
 	"github.com/pug-sh/pug/internal/slogx"
 )
 
@@ -16,9 +16,7 @@ func main() {
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	if err := godotenv.Load(); err != nil {
-		slog.DebugContext(ctx, "No .env file found, relying on environment variables")
-	}
+	dotenv.LoadOrExit(ctx)
 
 	if err := emailworker.Run(ctx); err != nil {
 		slog.ErrorContext(ctx, "error starting email worker", slogx.Error(err))

--- a/cmd/workers/events/main.go
+++ b/cmd/workers/events/main.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/joho/godotenv"
 	"github.com/pug-sh/pug/internal/app/workers/events"
+	"github.com/pug-sh/pug/internal/dotenv"
 	"github.com/pug-sh/pug/internal/slogx"
 )
 
@@ -16,9 +16,7 @@ func main() {
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	if err := godotenv.Load(); err != nil {
-		slog.DebugContext(ctx, "No .env file found, relying on environment variables")
-	}
+	dotenv.LoadOrExit(ctx)
 
 	if err := events.Run(ctx); err != nil {
 		slog.ErrorContext(ctx, "error starting events worker", slogx.Error(err))

--- a/cmd/workers/profile/alias/main.go
+++ b/cmd/workers/profile/alias/main.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/joho/godotenv"
 	"github.com/pug-sh/pug/internal/app/workers/profiles/alias"
+	"github.com/pug-sh/pug/internal/dotenv"
 	"github.com/pug-sh/pug/internal/slogx"
 )
 
@@ -16,9 +16,7 @@ func main() {
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	if err := godotenv.Load(); err != nil {
-		slog.DebugContext(ctx, "No .env file found, relying on environment variables")
-	}
+	dotenv.LoadOrExit(ctx)
 
 	if err := alias.Run(ctx); err != nil {
 		slog.ErrorContext(ctx, "error starting profile alias worker", slogx.Error(err))

--- a/cmd/workers/profile/identify/main.go
+++ b/cmd/workers/profile/identify/main.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/joho/godotenv"
 	"github.com/pug-sh/pug/internal/app/workers/profiles/identify"
+	"github.com/pug-sh/pug/internal/dotenv"
 	"github.com/pug-sh/pug/internal/slogx"
 )
 
@@ -16,9 +16,7 @@ func main() {
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	if err := godotenv.Load(); err != nil {
-		slog.DebugContext(ctx, "No .env file found, relying on environment variables")
-	}
+	dotenv.LoadOrExit(ctx)
 
 	if err := identify.Run(ctx); err != nil {
 		slog.ErrorContext(ctx, "error starting profile identify worker", slogx.Error(err))

--- a/cmd/workers/profile/upsert/main.go
+++ b/cmd/workers/profile/upsert/main.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/joho/godotenv"
 	"github.com/pug-sh/pug/internal/app/workers/profiles/upsert"
+	"github.com/pug-sh/pug/internal/dotenv"
 	"github.com/pug-sh/pug/internal/slogx"
 )
 
@@ -16,9 +16,7 @@ func main() {
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	if err := godotenv.Load(); err != nil {
-		slog.DebugContext(ctx, "No .env file found, relying on environment variables")
-	}
+	dotenv.LoadOrExit(ctx)
 
 	if err := upsert.Run(ctx); err != nil {
 		slog.ErrorContext(ctx, "error starting profile upsert worker", slogx.Error(err))

--- a/internal/dotenv/dotenv.go
+++ b/internal/dotenv/dotenv.go
@@ -1,0 +1,39 @@
+// Package dotenv loads the optional .env of a local checkout. Deployments ship
+// none and set real environment variables.
+package dotenv
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+
+	"github.com/joho/godotenv"
+	"github.com/pug-sh/pug/internal/slogx"
+)
+
+// Load applies .env without overriding the environment. godotenv reports a line
+// with no name as success, so that case is rejected here.
+func Load() error {
+	env, err := godotenv.Read()
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return nil
+	case err != nil:
+		return fmt.Errorf("load .env: %w", err)
+	}
+	if value, ok := env[""]; ok {
+		return fmt.Errorf("load .env: %q has no name", value)
+	}
+	return godotenv.Load()
+}
+
+// LoadOrExit logs and exits 1 when Load fails.
+func LoadOrExit(ctx context.Context) {
+	if err := Load(); err != nil {
+		slog.ErrorContext(ctx, "failed to load .env", slogx.Error(err)) // puglint:exempt — no span at startup
+		os.Exit(1)
+	}
+}

--- a/internal/dotenv/dotenv.go
+++ b/internal/dotenv/dotenv.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Load applies .env without overriding the environment. godotenv reports a line
-// with no name as success, so that case is rejected here.
+// with no name as success and discards os.Setenv errors, so both are caught here.
 func Load() error {
 	env, err := godotenv.Read()
 	switch {
@@ -27,7 +27,15 @@ func Load() error {
 	if value, ok := env[""]; ok {
 		return fmt.Errorf("load .env: %q has no name", value)
 	}
-	return godotenv.Load()
+	for name, value := range env {
+		if _, ok := os.LookupEnv(name); ok {
+			continue
+		}
+		if err := os.Setenv(name, value); err != nil {
+			return fmt.Errorf("load .env: %s: %w", name, err)
+		}
+	}
+	return nil
 }
 
 // LoadOrExit logs and exits 1 when Load fails.

--- a/internal/dotenv/dotenv_test.go
+++ b/internal/dotenv/dotenv_test.go
@@ -74,6 +74,18 @@ func TestLoadMalformedEnvFile(t *testing.T) {
 	}
 }
 
+// os.Setenv rejects a NUL byte and godotenv discards that error.
+func TestLoadRejectsUnsettableValue(t *testing.T) {
+	t.Chdir(writeEnv(t, "PUG_DOTENV_NUL=before\x00after\n"))
+
+	if err := dotenv.Load(); err == nil {
+		t.Fatal("Load() = nil, want an error for a value os.Setenv refuses")
+	}
+	if value, ok := os.LookupEnv("PUG_DOTENV_NUL"); ok {
+		t.Fatalf("PUG_DOTENV_NUL = %q, want unset", value)
+	}
+}
+
 // A directory rather than chmod 000: the test user may be root.
 func TestLoadUnreadableEnvFile(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/dotenv/dotenv_test.go
+++ b/internal/dotenv/dotenv_test.go
@@ -1,0 +1,129 @@
+package dotenv_test
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pug-sh/pug/internal/dotenv"
+)
+
+const subprocessEnv = "PUG_DOTENV_SUBPROCESS"
+
+func writeEnv(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestLoadWithoutEnvFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := dotenv.Load(); err != nil {
+		t.Fatalf("Load() = %v, want nil for an absent .env", err)
+	}
+}
+
+func TestLoadAppliesValues(t *testing.T) {
+	t.Chdir(writeEnv(t, "PUG_DOTENV_APPLIED=yes\n"))
+	t.Cleanup(func() { _ = os.Unsetenv("PUG_DOTENV_APPLIED") })
+
+	if err := dotenv.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv("PUG_DOTENV_APPLIED"); got != "yes" {
+		t.Fatalf("PUG_DOTENV_APPLIED = %q, want %q", got, "yes")
+	}
+}
+
+func TestLoadDoesNotOverride(t *testing.T) {
+	t.Chdir(writeEnv(t, "PUG_DOTENV_PRESET=from-file\n"))
+	t.Setenv("PUG_DOTENV_PRESET", "from-environment")
+
+	if err := dotenv.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv("PUG_DOTENV_PRESET"); got != "from-environment" {
+		t.Fatalf("PUG_DOTENV_PRESET = %q, want the exported value to win", got)
+	}
+}
+
+func TestLoadMalformedEnvFile(t *testing.T) {
+	// The eof cases have no trailing newline, where godotenv reports success.
+	for name, body := range map[string]string{
+		"unterminated quote":   "PUG_DOTENV_PARTIAL=1\nBROKEN=\"unterminated\n",
+		"no assignment":        "PUG_DOTENV_PARTIAL=1\nnot an assignment\n",
+		"no assignment at eof": "PUG_DOTENV_PARTIAL=1\nnot an assignment",
+		"bare name at eof":     "PUG_DOTENV_PARTIAL",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Chdir(writeEnv(t, body))
+			if err := dotenv.Load(); err == nil {
+				t.Fatal("Load() = nil, want an error for a .env this broken")
+			}
+			if value, ok := os.LookupEnv("PUG_DOTENV_PARTIAL"); ok {
+				t.Fatalf("PUG_DOTENV_PARTIAL = %q, want unset: a rejected .env must apply nothing", value)
+			}
+		})
+	}
+}
+
+// A directory rather than chmod 000: the test user may be root.
+func TestLoadUnreadableEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, ".env"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	if err := dotenv.Load(); err == nil {
+		t.Fatal("Load() = nil, want an error for an unreadable .env")
+	}
+}
+
+// Only a real process shows LoadOrExit's exit status.
+func runLoadOrExit(t *testing.T, dir string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestLoadOrExit$")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), subprocessEnv+"=1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stderr.String(), err
+}
+
+func TestLoadOrExit(t *testing.T) {
+	if os.Getenv(subprocessEnv) == "1" {
+		dotenv.LoadOrExit(t.Context())
+		return
+	}
+
+	t.Run("broken .env", func(t *testing.T) {
+		stderr, err := runLoadOrExit(t, writeEnv(t, "BROKEN=\"unterminated\n"))
+
+		var exit *exec.ExitError
+		if !errors.As(err, &exit) {
+			t.Fatalf("child exited with %v, want a non-zero status", err)
+		}
+		if got := exit.ExitCode(); got != 1 {
+			t.Fatalf("child exit code = %d, want 1", got)
+		}
+		// A failing test also exits 1, so the log line is what pins the exit to LoadOrExit.
+		if !strings.Contains(stderr, "failed to load .env") {
+			t.Fatalf("child stderr = %q, want the .env failure logged", stderr)
+		}
+	})
+
+	t.Run("no .env", func(t *testing.T) {
+		if stderr, err := runLoadOrExit(t, t.TempDir()); err != nil {
+			t.Fatalf("child exited with %v, want success; stderr = %q", err, stderr)
+		}
+	})
+}

--- a/internal/lint/depguard.go
+++ b/internal/lint/depguard.go
@@ -66,10 +66,10 @@ func checkDepguardTargets(root string) ([]string, error) {
 // globDir reduces "**/internal/core/**/*.go" to "internal/core", the literal
 // prefix the glob can never look outside of. Taking the prefix rather than
 // trimming the tail keeps a filename component ("*.go") from being stat'd as if
-// it were a directory. Negations and the $test placeholder name no directory,
-// so they are skipped.
+// it were a directory. A negation still names a directory; only $test names none.
 func globDir(pattern string) (string, bool) {
-	if strings.HasPrefix(pattern, "!") || strings.Contains(pattern, "$") {
+	pattern = strings.TrimPrefix(pattern, "!")
+	if strings.Contains(pattern, "$") {
 		return "", false
 	}
 	p := strings.TrimPrefix(pattern, "**/")


### PR DESCRIPTION
Every entry point read a malformed or unreadable .env as a missing one and started on inherited environment alone. One loader now classifies it, rejects godotenv's silent nameless-line success, and exits 1; a depguard rule pins it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent `.env` loading across application commands, workers, migrations, and email previews.
  - Existing environment variables are preserved when values are also defined in `.env`.

- **Bug Fixes**
  - Invalid or unreadable `.env` files now stop startup with a clear error instead of being silently ignored.
  - Missing `.env` files remain supported without preventing startup.
  - Improved validation prevents malformed environment entries from being partially applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->